### PR TITLE
docs: Add branch protection setup and configuration files

### DIFF
--- a/.github/BRANCH_PROTECTION_QUICK.md
+++ b/.github/BRANCH_PROTECTION_QUICK.md
@@ -1,0 +1,32 @@
+# Quick Branch Protection Setup
+
+## Single Developer - Recommended Settings
+
+**Direct Link:** https://github.com/lukaszzychal/phpstan-fixer/settings/branches
+
+### Configuration:
+
+**Branch name pattern:** `main`
+
+✅ **Check these:**
+- [x] Require a pull request before merging
+  - Require approvals: **0**
+- [x] Require status checks to pass before merging
+  - Require branches to be up to date before merging
+- [x] Require conversation resolution before merging
+- [x] Do not allow bypassing the above settings
+
+❌ **Uncheck these:**
+- [ ] Allow force pushes ⚠️ **IMPORTANT - Uncheck to prevent accidents**
+- [ ] Allow deletions ⚠️ **IMPORTANT - Uncheck to prevent accidents**
+
+### Why?
+- Protects against accidental `git push --force`
+- Protects against accidental branch deletion
+- Runs CI checks automatically
+- Still allows you to work normally (0 approvals needed)
+- Creates good PR workflow even for solo projects
+
+### If You Need to Force Push:
+You can temporarily disable protection via GitHub UI (Settings → Branches → Edit → Uncheck "Do not allow bypassing")
+

--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -1,0 +1,21 @@
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": []
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 0,
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false,
+    "require_last_push_approval": false
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": true,
+  "block_creations": false,
+  "lock_branch": false,
+  "allow_fork_syncing": false
+}
+

--- a/.github/update-branch-protection-checks.sh
+++ b/.github/update-branch-protection-checks.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Script to update branch protection with required status checks
+# Run this after first CI workflow completes to add status checks
+
+REPO="lukaszzychal/phpstan-fixer"
+BRANCH="main"
+
+echo "Updating branch protection for $BRANCH with status checks..."
+
+# Update branch protection to require specific status checks
+# Adjust these check names based on what appears in your CI workflow
+gh api repos/$REPO/branches/$BRANCH/protection/required_status_checks \
+  --method PATCH \
+  --field strict=true \
+  --field contexts[]='test (PHP 8.3 on ubuntu-latest)' \
+  --field contexts[]='Static Analysis (PHPStan)'
+
+echo "✅ Branch protection updated!"
+echo ""
+echo "To verify, check: https://github.com/$REPO/settings/branches"
+echo ""
+echo "To add more status checks, edit this script and add contexts[] entries."
+

--- a/BRANCH_PROTECTION.md
+++ b/BRANCH_PROTECTION.md
@@ -1,0 +1,109 @@
+# Branch Protection for Main Branch
+
+## Recommended Settings for Single Developer
+
+Since you're the only person working on this repository, here are the recommended settings that protect against accidents while not blocking your normal workflow.
+
+## Step-by-Step Instructions
+
+1. **Go to Repository Settings:**
+   - Navigate to: https://github.com/lukaszzychal/phpstan-fixer
+   - Click "⚙️ Settings" (top right)
+
+2. **Navigate to Branch Protection:**
+   - Click "Branches" in the left sidebar
+   - Click "Add rule" or "Add branch protection rule"
+
+3. **Configure Branch Name Pattern:**
+   - Branch name pattern: `main`
+
+4. **Recommended Settings (Single Developer):**
+
+   ✅ **Enable these:**
+   
+   - [x] **Require a pull request before merging**
+     - [x] Require approvals: **0** (since you're solo)
+     - [ ] Dismiss stale pull request approvals when new commits are pushed
+     - [ ] Require review from Code Owners
+   
+   - [x] **Require status checks to pass before merging**
+     - [x] Require branches to be up to date before merging
+     - [ ] Status checks found in the last week (select your CI checks):
+       - CI / PHP 8.0
+       - CI / PHP 8.1
+       - CI / PHP 8.2
+       - CI / PHP 8.3
+       - CI / PHP 8.4
+       - CI / PHP 8.5
+       - CI / PHPStan
+   
+   - [x] **Require conversation resolution before merging**
+   
+   - [x] **Do not allow bypassing the above settings**
+     - ⚠️ Note: Since you're solo, you might want to UNCHECK this so you can bypass if needed
+     - **Recommendation**: Keep it checked for safety, but you can bypass via GitHub CLI if needed
+   
+   - [x] **Restrict who can push to matching branches**
+     - Leave empty (allows you to push normally)
+   
+   - [x] **Allow force pushes** → **UNCHECK THIS** (important!)
+     - This prevents accidental `git push --force`
+   
+   - [x] **Allow deletions** → **UNCHECK THIS** (important!)
+     - This prevents accidental branch deletion
+   
+   - [x] **Allow lock branch**
+     - Keep this for temporary locks if needed
+
+5. **Click "Create" or "Save changes"**
+
+## Alternative: Less Restrictive (Maximum Flexibility)
+
+If you want maximum flexibility while still having basic protection:
+
+✅ **Minimal Protection:**
+- [x] Allow force pushes → **UNCHECK**
+- [x] Allow deletions → **UNCHECK**
+- [ ] Everything else → **UNCHECK**
+
+This gives you:
+- ✅ Protection against accidental force push
+- ✅ Protection against accidental deletion
+- ✅ No workflow blocking
+
+## Force Push Workaround (If Needed)
+
+If you need to force push in emergency (and bypass is disabled):
+
+**Option 1: Use GitHub CLI**
+```bash
+gh api repos/lukaszzychal/phpstan-fixer/branches/main/protection --method DELETE
+git push --force origin main
+gh api repos/lukaszzychal/phpstan-fixer/branches/main/protection --method PUT -f required_status_checks=null -f enforce_admins=false -f restrictions=null
+```
+
+**Option 2: Temporarily disable protection via GitHub UI**
+- Settings → Branches → Edit rule → Temporarily uncheck "Do not allow bypassing"
+
+## Recommended: Balanced Approach
+
+For a single developer, I recommend this **balanced configuration**:
+
+### ✅ Enable:
+- [x] Require a pull request before merging (with 0 approvals)
+- [x] Require status checks to pass before merging
+- [x] Require conversation resolution before merging
+- [x] Do not allow bypassing the above settings
+- [ ] Allow force pushes → **UNCHECK** ⚠️
+- [ ] Allow deletions → **UNCHECK** ⚠️
+
+### Why this setup?
+- ✅ Prevents accidental force push (you can still push normally)
+- ✅ Prevents accidental branch deletion
+- ✅ Runs CI checks before merge (catches errors early)
+- ✅ Allows you to merge your own PRs (0 approvals)
+- ✅ Still requires PR workflow (good practice even solo)
+- ⚠️ Bypass disabled (but you can temporarily enable if needed)
+
+This gives you protection without blocking your normal workflow!
+

--- a/BRANCH_PROTECTION_SETUP.md
+++ b/BRANCH_PROTECTION_SETUP.md
@@ -1,0 +1,108 @@
+# Branch Protection Setup - Step by Step
+
+## Quick Setup Link
+**Direct link to branch protection settings:**
+https://github.com/lukaszzychal/phpstan-fixer/settings/branches
+
+## Recommended Configuration for Single Developer
+
+### Step 1: Create Protection Rule
+1. Click **"Add rule"** button
+2. In "Branch name pattern", enter: `main`
+3. Press Enter or click outside
+
+### Step 2: Configure Protection Rules
+
+#### ✅ Check These Options:
+
+**1. Require a pull request before merging**
+   - [x] ✅ Enable this checkbox
+   - Set "Required number of approvals before merging": **0** (since you're solo)
+   - [ ] Leave "Dismiss stale pull request approvals..." unchecked
+   - [ ] Leave "Require review from Code Owners" unchecked
+
+**2. Require status checks to pass before merging**
+   - [x] ✅ Enable this checkbox
+   - [x] ✅ Check "Require branches to be up to date before merging"
+   - Under "Status checks that are required":
+     - These will appear after first CI run, but you can add:
+     - `test (PHP 8.0 on ubuntu-latest)`
+     - `test (PHP 8.3 on ubuntu-latest)` ← at minimum
+     - `Static Analysis (PHPStan)`
+     - **Note**: Status check names appear after workflow runs. You may need to run CI once first, then come back and select them.
+
+**3. Require conversation resolution before merging**
+   - [x] ✅ Enable this checkbox
+
+**4. Do not allow bypassing the above settings**
+   - [x] ✅ Enable this checkbox (for safety)
+   - ⚠️ Note: You can temporarily disable this if you need to bypass in emergency
+
+#### ❌ Uncheck These (IMPORTANT!):
+
+**5. Allow force pushes**
+   - [ ] ❌ **UNCHECK THIS** - Prevents accidental `git push --force`
+
+**6. Allow deletions**
+   - [ ] ❌ **UNCHECK THIS** - Prevents accidental branch deletion
+
+**7. Allow lock branch**
+   - [x] ✅ You can leave this checked (allows temporary locks if needed)
+
+### Step 3: Save
+Click **"Create"** or **"Save changes"** button
+
+## What This Gives You:
+
+✅ **Protection:**
+- Prevents accidental force push (`git push --force` will be blocked)
+- Prevents accidental branch deletion
+- Requires CI checks to pass before merging PRs
+- Creates good workflow even for solo projects
+
+✅ **Flexibility:**
+- 0 approvals needed (you can merge your own PRs immediately)
+- Can work on feature branches and merge via PR
+- Can temporarily disable bypass if needed in emergency
+
+⚠️ **If You Need to Force Push:**
+1. Go to Settings → Branches
+2. Edit the `main` rule
+3. Temporarily uncheck "Do not allow bypassing"
+4. Do your force push
+5. Re-enable "Do not allow bypassing"
+
+## Status Checks Setup (After First CI Run)
+
+After your first CI workflow runs on a PR, you'll see status check names. Then:
+
+1. Go back to Settings → Branches
+2. Edit the `main` rule
+3. Scroll to "Require status checks to pass before merging"
+4. You'll see a list of available checks - select at minimum:
+   - `test (PHP 8.3 on ubuntu-latest)` ← recommended minimum
+   - `Static Analysis (PHPStan)` ← highly recommended
+
+**Or select all PHP versions** for maximum protection (slower but safer):
+   - `test (PHP 8.0 on ubuntu-latest)`
+   - `test (PHP 8.1 on ubuntu-latest)`
+   - `test (PHP 8.2 on ubuntu-latest)`
+   - `test (PHP 8.3 on ubuntu-latest)`
+   - `test (PHP 8.4 on ubuntu-latest)`
+   - `test (PHP 8.5 on ubuntu-latest)`
+   - `Static Analysis (PHPStan)`
+
+## Minimal Setup (If You Want Less Protection)
+
+If you want only basic protection without PR requirements:
+
+**Enable only:**
+- [x] Allow force pushes → **UNCHECK**
+- [x] Allow deletions → **UNCHECK**
+- Everything else → **UNCHECK**
+
+This gives:
+- ✅ Protection against accidental force push
+- ✅ Protection against accidental deletion
+- ❌ No CI checks required (you can skip if needed)
+

--- a/GITHUB_SETUP.md
+++ b/GITHUB_SETUP.md
@@ -1,0 +1,86 @@
+# GitHub Repository Setup Instructions
+
+## 1. Update Repository Description
+
+### Current (Polish):
+```
+Pakiet z narzędziami automatyzującymi poprawki błędów PHPStan. Udostępnia parser logów, strategie refaktoryzacji i komendy wspierające utrzymanie wysokiej jakości kodu w projektach PHP 8.2+.
+```
+
+### Replace with (English):
+```
+Framework-agnostic PHP library for automatically fixing PHPStan errors using static analysis. Provides log parser, refactoring strategies, and commands supporting high code quality in PHP 8.0+ projects.
+```
+
+**How to update:**
+1. Go to: https://github.com/lukaszzychal/phpstan-fixer
+2. Click "⚙️ Settings" (top right)
+3. Scroll down to "Repository details"
+4. Edit "Description" field
+5. Paste the English description above
+6. Click "Save changes"
+
+---
+
+## 2. Packagist Tag Issue - Fixed ✅
+
+Both tags have been pushed to GitHub:
+- ✅ `v1.0.0` - pushed
+- ✅ `v1.0.1` - pushed
+
+### Verify Tags on GitHub:
+Check: https://github.com/lukaszzychal/phpstan-fixer/tags
+
+You should see both tags listed there.
+
+### Packagist Auto-Update
+
+Packagist should automatically detect the tags within 5-10 minutes. If tags don't appear on Packagist:
+
+1. **Wait a few minutes** - Packagist checks for updates periodically
+2. **Manually trigger update:**
+   - Go to: https://packagist.org/packages/lukaszzychal/phpstan-fixer
+   - Look for "Update" button and click it
+   - Or use API: `curl -X POST https://packagist.org/api/update-package?username=YOUR_USERNAME&apiToken=YOUR_TOKEN&repository=https://github.com/lukaszzychal/phpstan-fixer`
+
+3. **Check GitHub Webhook:**
+   - Go to: https://github.com/lukaszzychal/phpstan-fixer/settings/hooks
+   - Look for Packagist webhook
+   - Verify it's active and receiving events
+
+4. **Verify Packagist Integration:**
+   - Go to Packagist → Submit → Connect GitHub
+   - Ensure repository is connected
+   - Repository should show "Auto-updated" status
+
+### Expected Packagist Output
+
+After update, Packagist should show:
+- `v1.0.0` (stable release)
+- `v1.0.1` (stable release)
+- `dev-main` (development branch)
+
+---
+
+## 3. Repository Topics
+
+Add these topics to your GitHub repository:
+- `phpstan`
+- `static-analysis`
+- `code-fixer`
+- `phpdoc`
+- `automation`
+- `code-quality`
+- `php`
+- `laravel`
+- `symfony`
+- `phpstan-error-fixer`
+- `automated-refactoring`
+
+**How to add topics:**
+1. Go to repository main page
+2. Click gear icon ⚙️ next to "About" section
+3. Add topics in the "Topics" field
+4. Press Enter after each topic
+5. Click "Save changes"
+

--- a/PACKAGIST_VERSION_FIX.md
+++ b/PACKAGIST_VERSION_FIX.md
@@ -1,0 +1,44 @@
+# Packagist Version Mismatch - Solution
+
+## Problem
+Packagist shows: "Some tags were ignored because of a version mismatch in composer.json"
+
+## Root Cause
+The `composer.json` file had a hardcoded `"version": "1.0.0"` field. Packagist automatically detects version from Git tags (e.g., `v1.0.0` → `1.0.0`, `v1.0.1` → `1.0.1`), and having a hardcoded version field can cause conflicts.
+
+## Solution Applied
+Removed the `"version"` field from `composer.json`. This is the recommended practice for Packagist packages - let Packagist auto-detect version from Git tags.
+
+## What Changed
+```diff
+-     "version": "1.0.0",
+```
+
+## Next Steps
+
+1. **Commit and push the change:**
+   ```bash
+   git add composer.json
+   git commit -m "fix: Remove version field from composer.json (let Packagist auto-detect from tags)"
+   git push origin main
+   ```
+
+2. **Packagist will auto-update:**
+   - Packagist checks for updates periodically (every few minutes)
+   - The tags should now be recognized correctly
+   - Check: https://packagist.org/packages/lukaszzychal/phpstan-fixer
+
+3. **If tags still don't appear:**
+   - Wait 5-10 minutes
+   - Manually trigger update on Packagist (Update button)
+   - Check Packagist logs for any errors
+
+## Why This Works
+- Packagist reads version from Git tag names (e.g., `v1.0.0`, `v1.0.1`)
+- Without `version` field in composer.json, there's no conflict
+- Tag `v1.0.0` → Package version `1.0.0`
+- Tag `v1.0.1` → Package version `1.0.1`
+
+## Best Practice
+**Never include `version` field in composer.json** for Packagist packages. Let Packagist detect it automatically from Git tags.
+

--- a/REPOSITORY_DESCRIPTION.md
+++ b/REPOSITORY_DESCRIPTION.md
@@ -1,0 +1,53 @@
+# Repository Description (English)
+
+Use this description for the GitHub repository:
+
+**Short description (max 160 characters):**
+```
+Framework-agnostic PHP library for automatically fixing PHPStan errors using static analysis. Works with Laravel, Symfony, CodeIgniter, and native PHP projects.
+```
+
+**Full description:**
+```
+Framework-agnostic PHP library for automatically fixing PHPStan errors using static analysis. Works with Laravel, Symfony, CodeIgniter, and native PHP projects.
+
+## Features
+
+- Automatically detects and fixes common PHPStan errors
+- Framework-agnostic (works with any PHP project)
+- Offline-friendly (no AI or network access required)
+- Suggest mode (preview changes) and Apply mode (write changes)
+- Supports multiple fix strategies for different error types
+
+## Installation
+
+```bash
+composer require --dev lukaszzychal/phpstan-fixer
+```
+
+## Quick Start
+
+```bash
+# Preview fixes (safe, no file changes)
+vendor/bin/phpstan-fixer
+
+# Apply fixes (modifies files)
+vendor/bin/phpstan-fixer --mode=apply
+```
+
+Requires PHP 8.0+ and PHPStan.
+```
+
+**Topics/Tags to add:**
+- phpstan
+- static-analysis
+- code-fixer
+- phpdoc
+- automation
+- code-quality
+- php
+- laravel
+- symfony
+- phpstan-error-fixer
+- automated-refactoring
+


### PR DESCRIPTION
## Changes

- Add branch protection configuration via GitHub API
- Add setup instructions and documentation (BRANCH_PROTECTION_SETUP.md, BRANCH_PROTECTION.md)
- Add helper script for updating status checks (.github/update-branch-protection-checks.sh)
- Add documentation files:
  - GITHUB_SETUP.md - GitHub repository setup instructions
  - PACKAGIST_VERSION_FIX.md - Packagist version mismatch fix documentation
  - REPOSITORY_DESCRIPTION.md - Repository description templates

## Notes

Branch protection for main is already configured via GitHub API.
This PR adds documentation and helper files for future reference.