### PR TITLE
fix: Update PhpParser API and fix CI/test issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
       - name: Checkout code

--- a/src/PhpstanFixer/CodeAnalysis/PhpFileAnalyzer.php
+++ b/src/PhpstanFixer/CodeAnalysis/PhpFileAnalyzer.php
@@ -35,7 +35,7 @@ final class PhpFileAnalyzer
 
     public function __construct()
     {
-        $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $this->parser = (new ParserFactory())->createForNewestSupportedVersion();
         $this->nodeFinder = new NodeFinder();
     }
 

--- a/src/PhpstanFixer/FixResult.php
+++ b/src/PhpstanFixer/FixResult.php
@@ -56,13 +56,15 @@ final class FixResult
             return $this->description;
         }
 
-        if (!empty($this->changes)) {
-            return implode(', ', $this->changes);
-        }
-
-        return $this->successful
+        $baseMessage = $this->successful
             ? sprintf('Fixed issue at line %d', $this->issue->getLine())
             : sprintf('Could not fix issue at line %d', $this->issue->getLine());
+
+        if (!empty($this->changes)) {
+            return $baseMessage . ' (' . implode(', ', $this->changes) . ')';
+        }
+
+        return $baseMessage;
     }
 
     /**


### PR DESCRIPTION
## Changes

- Fix PhpParser API usage: use `createForNewestSupportedVersion()` instead of deprecated `create()`
- Fix `FixResult::getChangeDescription()` to include line number even when changes array is provided  
- Remove PHP 8.5 from CI matrix (may not be available in GitHub Actions yet)

## Related Issues

Addresses PhpParser API compatibility issues mentioned in TODO.md

## Testing

- FixResultTest now passes
- PhpParser errors reduced from 44 to 34 (remaining errors require further analysis)