### PR TITLE
fix: Implement robust autoloader detection in binary script

### DIFF
--- a/bin/phpstan-fixer
+++ b/bin/phpstan-fixer
@@ -18,7 +18,34 @@ declare(strict_types=1);
  * @author Łukasz Zychal <lukasz@zychal.pl>
  */
 
-require_once __DIR__ . '/../vendor/autoload.php';
+// Find the autoloader by traversing up the directory tree
+// This works both when package is standalone and when installed as dependency
+$autoloader = null;
+$dir = __DIR__;
+$maxDepth = 10; // Prevent infinite loops
+
+for ($i = 0; $i < $maxDepth; $i++) {
+    $possiblePath = $dir . '/vendor/autoload.php';
+    if (file_exists($possiblePath)) {
+        $autoloader = $possiblePath;
+        break;
+    }
+    
+    $parentDir = dirname($dir);
+    if ($parentDir === $dir) {
+        // Reached filesystem root
+        break;
+    }
+    $dir = $parentDir;
+}
+
+if ($autoloader === null) {
+    fwrite(STDERR, "Error: Could not find autoload.php.\n");
+    fwrite(STDERR, "Please run 'composer install' to install dependencies.\n");
+    exit(1);
+}
+
+require_once $autoloader;
 
 use PhpstanFixer\Command\PhpstanAutoFixCommand;
 use Symfony\Component\Console\Application;


### PR DESCRIPTION
## Summary

Fixes #8 - Binary script fails when package is installed as dependency

## Problem

The binary script tried to load `vendor/autoload.php` from the package's own directory, which doesn't exist when installed via Composer as a dependency.

## Solution

Implemented dynamic autoloader detection that:
- Traverses up the directory tree (max 10 levels)
- Works in both standalone and dependency installation scenarios
- Provides helpful error message if autoloader not found

## Testing

- ✅ Binary works when package is standalone
- ✅ Binary works when installed as dependency (tested locally)
- ✅ PHPStan analysis passes
- ✅ All tests pass (64 tests, 124 assertions)

## Backward Compatibility

✅ Fully backward compatible - works in all existing scenarios

Closes #8