### PR TITLE
feat: Add PHP Compatibility Tester integration

### DIFF
--- a/.compatibility.yml
+++ b/.compatibility.yml
@@ -1,0 +1,33 @@
+package_name: "lukaszzychal/phpstan-fixer"
+
+php_versions: ['8.1', '8.2', '8.3', '8.4']
+
+frameworks:
+  laravel:
+    versions: ['11.*', '12.*']
+    install_command: 'composer create-project laravel/laravel'
+    php_min_version: '8.1'
+  
+  symfony:
+    versions: ['7.4.*', '8.0.*']
+    install_command: 'composer create-project symfony/skeleton'
+    php_min_version: '8.1'
+  
+  codeigniter:
+    versions: ['4.*', '5.*']
+    install_command: 'composer create-project codeigniter4/appstarter'
+    php_min_version: '8.1'
+
+test_scripts:
+  - name: "Autoload test"
+    command: "composer dump-autoload && php -r \"require 'vendor/autoload.php'; echo 'Autoload OK';\""
+  
+  - name: "Binary test"
+    command: "vendor/bin/phpstan-fixer --help"
+  
+  - name: "Basic functionality test"
+    command: "php -r \"require 'vendor/autoload.php'; use PhpstanFixer\\AutoFixService; echo 'Classes loaded OK';\""
+
+github_actions:
+  enabled: true
+

--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -1,0 +1,58 @@
+name: Compatibility Tests
+
+on:
+  # Run monthly on the 1st day at 2 AM UTC
+  schedule:
+    - cron: '0 2 1 * *'  # Monthly on 1st day at 2 AM UTC
+  # Manual trigger (workflow_dispatch)
+  workflow_dispatch:
+  # Optional: Run on release tags (uncomment if needed)
+  # push:
+  #   tags:
+  #     - 'v*'
+
+jobs:
+  compatibility-tests:
+    name: PHP Compatibility Tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.1', '8.2', '8.3', '8.4']
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: mbstring, xml, curl, json
+          coverage: none
+      
+      - name: Install Composer
+        uses: php-actions/composer@v1
+        with:
+          command: install
+          args: --no-interaction --prefer-dist
+      
+      - name: Run compatibility tests and generate report
+        if: always()
+        run: |
+          # Report command automatically runs tests if needed, then generates report
+          vendor/bin/compatibility-tester report \
+            --format=markdown \
+            --output=compatibility-report.md || true
+        continue-on-error: true
+        env:
+          PHP_VERSION: ${{ matrix.php-version }}
+      
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compatibility-report-php-${{ matrix.php-version }}
+          path: compatibility-report.md
+          retention-days: 30
+

--- a/ISSUE_COMPATIBILITY_TESTER_FIXES.md
+++ b/ISSUE_COMPATIBILITY_TESTER_FIXES.md
@@ -1,0 +1,180 @@
+# Issue: Compatibility with Symfony Console 7.x - Fatal Error and Deprecation Warnings
+
+## Summary
+
+The package `lukaszzychal/php-compatibility-tester` v1.0.1 has compatibility issues with Symfony Console 7.x that cause fatal errors when running commands. Additionally, there are deprecation warnings related to nullable parameter syntax.
+
+## Problem Description
+
+### Fatal Error: Command Name Not Set
+
+**Error Message:**
+```
+Fatal error: Uncaught Symfony\Component\Console\Exception\LogicException: 
+The command defined in "LukaszZychal\PhpCompatibilityTester\Command\InitCommand" 
+cannot have an empty name.
+```
+
+**Root Cause:**
+In Symfony Console 7.x, the `protected static $defaultName` property is not automatically recognized when commands are instantiated before being added to the Application. The command name must be explicitly set using `setName()` in the `configure()` method.
+
+**Affected Commands:**
+- `InitCommand`
+- `TestCommand`
+- `ReportCommand`
+
+### Deprecation Warning
+
+**Warning Message:**
+```
+Deprecated: LukaszZychal\PhpCompatibilityTester\Command\InitCommand::__construct(): 
+Implicitly marking parameter $packagePath as nullable is deprecated, 
+the explicit nullable type must be used instead
+```
+
+**Root Cause:**
+PHP 8.4+ (and strict deprecation warnings in PHP 8.1+) require explicit nullable type syntax (`?string`) instead of implicit nullable with default `null` (`string $param = null`).
+
+**Location:**
+- `src/Command/InitCommand.php:22`
+
+### Additional Issue: Option Name Conflict
+
+**Error Message:**
+```
+An option named "version" already exists.
+```
+
+**Root Cause:**
+The `TestCommand` defines an option `--version` which conflicts with Symfony Console's built-in `--version` option for the Application.
+
+**Location:**
+- `src/Command/TestCommand.php:29`
+
+## Environment
+
+- **Package Version:** v1.0.1
+- **Symfony Console:** 7.4.0 (but issue affects all 7.x versions)
+- **PHP Version:** 8.4.7 (deprecation warnings also appear in 8.1+)
+- **OS:** macOS / Linux
+
+## Reproduction Steps
+
+1. Install the package:
+   ```bash
+   composer require --dev lukaszzychal/php-compatibility-tester
+   ```
+
+2. Run any command:
+   ```bash
+   vendor/bin/compatibility-tester --help
+   # or
+   vendor/bin/compatibility-tester init
+   # or
+   vendor/bin/compatibility-tester test --help
+   ```
+
+3. **Expected:** Command executes successfully
+4. **Actual:** Fatal error occurs
+
+## Proposed Solution
+
+### Fix 1: Explicit Command Name Setting
+
+Add `setName()` calls in `configure()` method for all commands:
+
+**File: `src/Command/InitCommand.php`**
+```php
+protected function configure(): void
+{
+    $this->setName('init');  // Add this line
+    $this->setDescription('Initialize compatibility testing configuration and templates');
+}
+```
+
+**File: `src/Command/TestCommand.php`**
+```php
+protected function configure(): void
+{
+    $this
+        ->setName('test')  // Add this line
+        ->setDescription('Run compatibility tests')
+        ->addOption('framework', 'f', InputOption::VALUE_REQUIRED, 'Filter by framework name')
+        // ... rest of options
+}
+```
+
+**File: `src/Command/ReportCommand.php`**
+```php
+protected function configure(): void
+{
+    $this
+        ->setName('report')  // Add this line
+        ->setDescription('Generate compatibility test report')
+        // ... rest of options
+}
+```
+
+### Fix 2: Explicit Nullable Parameter Syntax
+
+**File: `src/Command/InitCommand.php`**
+```php
+// Change from:
+public function __construct(string $packagePath = null)
+
+// To:
+public function __construct(?string $packagePath = null)
+```
+
+### Fix 3: Rename Conflicting Option (Optional Enhancement)
+
+**File: `src/Command/TestCommand.php`**
+```php
+// Change from:
+->addOption('version', null, InputOption::VALUE_REQUIRED, 'Filter by framework version')
+
+// To:
+->addOption('framework-version', null, InputOption::VALUE_REQUIRED, 'Filter by framework version')
+```
+
+**Note:** This is a breaking change. Consider:
+- Deprecating `--version` and adding `--framework-version`
+- Or keeping `--version` but documenting the conflict with `--version` (application version)
+
+## Compatibility
+
+- ✅ **Backward Compatible:** Yes (Fix 1 and Fix 2 are internal fixes, no API changes)
+- ⚠️ **Breaking Change:** Fix 3 (option rename) would be a breaking change if implemented
+- ✅ **PHP Version Support:** Maintains support for PHP 8.1+
+- ✅ **Symfony Console:** Compatible with both 6.x and 7.x
+
+## Testing
+
+After applying fixes, verify:
+1. `vendor/bin/compatibility-tester --help` works
+2. `vendor/bin/compatibility-tester list` shows all commands
+3. `vendor/bin/compatibility-tester init` executes without errors
+4. `vendor/bin/compatibility-tester test --help` works
+5. `vendor/bin/compatibility-tester report --help` works
+6. No deprecation warnings appear (PHP 8.1+)
+
+## Additional Notes
+
+- The `protected static $defaultName` property can remain for Symfony Console 6.x compatibility, but `setName()` is required for 7.x
+- This is a known Symfony Console 7.x change: commands must explicitly set their name in `configure()` method
+- All fixes are minimal and maintain full backward compatibility
+
+## Priority
+
+- **Severity:** High (package is unusable with Symfony Console 7.x)
+- **Impact:** All users installing with Symfony Console 7.x will experience fatal errors
+- **Fix Complexity:** Low (simple code changes, well-documented)
+
+---
+
+**Tested Fixes:**
+- ✅ Applied all three fixes locally
+- ✅ Verified all commands work correctly
+- ✅ No breaking changes for existing functionality
+- ✅ Compatible with Symfony Console 7.4.0 and PHP 8.4.7
+

--- a/README.md
+++ b/README.md
@@ -206,6 +206,20 @@ The project uses GitHub Actions for continuous integration:
 
 See [`.github/workflows/`](.github/workflows/) for details.
 
+### Compatibility Testing
+
+This package uses [PHP Compatibility Tester](https://github.com/lukaszzychal/php-compatibility-tester) to ensure compatibility across different frameworks and PHP versions:
+
+- **Packagist**: [lukaszzychal/php-compatibility-tester](https://packagist.org/packages/lukaszzychal/php-compatibility-tester)
+- **GitHub**: [lukaszzychal/php-compatibility-tester](https://github.com/lukaszzychal/php-compatibility-tester)
+
+Compatibility tests run automatically:
+- **Monthly**: On the 1st day of each month via GitHub Actions
+- **Manually**: Trigger via GitHub Actions UI (workflow_dispatch)
+- **Locally**: Run `vendor/bin/compatibility-tester test` to test locally
+
+This automatically tests `phpstan-fixer` against various frameworks (Laravel 11/12, Symfony 7/8, CodeIgniter 4/5) and PHP versions (8.1-8.4) to ensure it works correctly in different environments. Test reports are available as GitHub Actions artifacts.
+
 ### Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "symfony/console": "^6.0|^7.0"
     },
     "require-dev": {
+        "lukaszzychal/php-compatibility-tester": "^1.1",
         "phpstan/phpstan": "^1.10 || ^2.0",
         "phpunit/phpunit": "^10.0"
     },
@@ -57,4 +58,3 @@
     "minimum-stability": "stable",
     "prefer-stable": true
 }
-


### PR DESCRIPTION
## Summary

Adds PHP Compatibility Tester integration for automated compatibility testing across different frameworks and PHP versions.

## Changes

- ✅ Added `.compatibility.yml` configuration
  - Tests against Laravel (11.*, 12.*), Symfony (7.4.*, 8.0.*), CodeIgniter (4.*, 5.*)
  - PHP versions: 8.1, 8.2, 8.3, 8.4
  - Custom test scripts for autoload, binary, and basic functionality

- ✅ Added GitHub Actions workflow
  - Monthly schedule: 1st day of month, 2:00 UTC
  - Manual trigger available (workflow_dispatch)
  - Test reports as artifacts (30 days retention)

- ✅ Updated README.md
  - Added Compatibility Testing section
  - Links to Packagist and GitHub
  - Usage instructions

- ✅ Updated composer.json
  - Requires `php-compatibility-tester ^1.1` (fixes Symfony Console 7.x compatibility)

- ✅ Added issue documentation
  - `ISSUE_COMPATIBILITY_TESTER_FIXES.md` with detailed problem analysis and solutions

## Testing

- ✅ Package updated to v1.1.0 (all fixes included)
- ✅ All commands tested: init, test, report
- ✅ No fatal errors or deprecation warnings
- ✅ Compatible with PHP 8.4.7 and Symfony Console 7.x

## Benefits

- Automated compatibility verification across frameworks
- Monthly reports to catch breaking changes early
- Framework-agnostic package validation
- CI/CD integration ready

## Related

- Package: https://packagist.org/packages/lukaszzychal/php-compatibility-tester
- GitHub: https://github.com/lukaszzychal/php-compatibility-tester
- Fixes documented in ISSUE_COMPATIBILITY_TESTER_FIXES.md