### PR TITLE
feat: add require implements fixer

### DIFF
--- a/IMPLEMENTED_FIXERS.md
+++ b/IMPLEMENTED_FIXERS.md
@@ -78,10 +78,10 @@
 - **Naprawa:** Dodaje `@phpstan-require-extends ClassName` na interfejsie/trait
 - **Status:** Zaimplementowane
 
-#### 5. ❌ RequireImplementsFixer
+#### 5. ✅ RequireImplementsFixer
 - **Błąd:** Trait wymaga implementacji interfejsu
 - **Naprawa:** Dodaje `@phpstan-require-implements InterfaceName` na trait
-- **Status:** NIE zaimplementowane
+- **Status:** Zaimplementowane
 
 #### 6. ❌ ReadonlyPropertyFixer
 - **Błąd:** Property assigned outside of declaring class (PHP < 8.1)

--- a/TODO.md
+++ b/TODO.md
@@ -49,7 +49,7 @@ See [ROADMAP.md](ROADMAP.md) for detailed planning.
 ### 6. RequireImplementsFixer
 - **Error Pattern:** Trait requires interface implementation
 - **Fix:** Add `@phpstan-require-implements InterfaceName` on trait
-- **Status:** Not implemented
+- **Status:** Implemented (see RequireImplementsFixer)
 - **Reference:** PHPStan docs - Enforcing implementing interface section
 
 ## Low Priority

--- a/src/PhpstanFixer/CodeAnalysis/DocblockManipulator.php
+++ b/src/PhpstanFixer/CodeAnalysis/DocblockManipulator.php
@@ -108,6 +108,7 @@ final class DocblockManipulator
             'phpstan-impure' => [],
             'phpstan-pure' => [],
             'phpstan-require-extends' => [],
+            'phpstan-require-implements' => [],
         ];
 
         // Remove /** and */ markers
@@ -239,6 +240,16 @@ final class DocblockManipulator
                     ];
                 }
                 break;
+
+            case 'phpstan-require-implements':
+                // @phpstan-require-implements InterfaceName
+                if (preg_match('/^([\\\\\w]+)(?:\s+(.+))?$/', $value, $matches)) {
+                    return [
+                        'className' => $matches[1],
+                        'description' => $matches[2] ?? null,
+                    ];
+                }
+                break;
         }
 
         return ['raw' => $value];
@@ -339,6 +350,7 @@ final class DocblockManipulator
             'phpstan-impure',
             'phpstan-pure',
             'phpstan-require-extends',
+            'phpstan-require-implements',
             'throws',
             'var',
             'property',
@@ -462,6 +474,13 @@ final class DocblockManipulator
                 return '';
 
             case 'phpstan-require-extends':
+                $result = $data['className'] ?? '';
+                if (isset($data['description'])) {
+                    $result .= ' ' . $data['description'];
+                }
+                return trim($result);
+
+            case 'phpstan-require-implements':
                 $result = $data['className'] ?? '';
                 if (isset($data['description'])) {
                     $result .= ' ' . $data['description'];

--- a/src/PhpstanFixer/Command/PhpstanAutoFixCommand.php
+++ b/src/PhpstanFixer/Command/PhpstanAutoFixCommand.php
@@ -29,6 +29,7 @@ use PhpstanFixer\Strategy\MixinFixer;
 use PhpstanFixer\Strategy\PrefixedTagsFixer;
 use PhpstanFixer\Strategy\ReadonlyPropertyFixer;
 use PhpstanFixer\Strategy\RequireExtendsFixer;
+use PhpstanFixer\Strategy\RequireImplementsFixer;
 use PhpstanFixer\Strategy\UndefinedMethodFixer;
 use PhpstanFixer\Strategy\UndefinedPivotPropertyFixer;
 use PhpstanFixer\Strategy\UndefinedVariableFixer;
@@ -358,6 +359,7 @@ final class PhpstanAutoFixCommand extends Command
             new PrefixedTagsFixer($analyzer, $docblockManipulator),
             new ImpureFunctionFixer($analyzer, $docblockManipulator),
             new RequireExtendsFixer($analyzer, $docblockManipulator),
+            new RequireImplementsFixer($analyzer, $docblockManipulator),
         ];
 
         return new AutoFixService($strategies, $configuration);

--- a/src/PhpstanFixer/Strategy/RequireImplementsFixer.php
+++ b/src/PhpstanFixer/Strategy/RequireImplementsFixer.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * Copyright (c) 2025 Łukasz Zychal
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpstanFixer\Strategy;
+
+use PhpstanFixer\CodeAnalysis\DocblockManipulator;
+use PhpstanFixer\CodeAnalysis\PhpFileAnalyzer;
+use PhpstanFixer\FixResult;
+use PhpstanFixer\Issue;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\NodeFinder;
+
+/**
+ * Adds @phpstan-require-implements InterfaceName to traits requiring specific interface implementation.
+ *
+ * @author Łukasz Zychal <lukasz.zychal.dev@gmail.com>
+ */
+final class RequireImplementsFixer implements FixStrategyInterface
+{
+    public function __construct(
+        private readonly PhpFileAnalyzer $analyzer,
+        private readonly DocblockManipulator $docblockManipulator
+    ) {
+        $this->nodeFinder = new NodeFinder();
+    }
+
+    private NodeFinder $nodeFinder;
+
+    public function canFix(Issue $issue): bool
+    {
+        return (bool) preg_match('/require(?:s)?\s+implements\s+[\\\\\w]+/i', $issue->getMessage());
+    }
+
+    public function fix(Issue $issue, string $fileContent): FixResult
+    {
+        if (!file_exists($issue->getFilePath())) {
+            return FixResult::failure($issue, $fileContent, 'File does not exist');
+        }
+
+        $ast = $this->analyzer->parse($fileContent);
+        if ($ast === null) {
+            return FixResult::failure($issue, $fileContent, 'Could not parse file');
+        }
+
+        $interface = $this->extractInterface($issue->getMessage());
+        if ($interface === null) {
+            return FixResult::failure($issue, $fileContent, 'Could not extract interface name');
+        }
+
+        [$classNode, $classLine] = $this->findClassLikeAtLine($ast, $issue->getLine()) ?? [null, null];
+        if ($classNode === null || $classLine === null) {
+            return FixResult::failure($issue, $fileContent, 'Could not locate trait for annotation');
+        }
+
+        $lines = explode("\n", $fileContent);
+        $classIndex = $classLine - 1;
+        $docblock = $this->docblockManipulator->extractDocblock($lines, $classIndex);
+
+        if ($docblock !== null) {
+            $parsed = $this->docblockManipulator->parseDocblock($docblock['content']);
+            foreach ($parsed['phpstan-require-implements'] ?? [] as $existing) {
+                if (($existing['className'] ?? null) === $interface) {
+                    return FixResult::failure(
+                        $issue,
+                        $fileContent,
+                        "@phpstan-require-implements already exists for {$interface}"
+                    );
+                }
+            }
+
+            $updated = $this->docblockManipulator->addAnnotation(
+                $docblock['content'],
+                'phpstan-require-implements',
+                $interface
+            );
+
+            $docblockLines = explode("\n", $updated);
+            array_splice(
+                $lines,
+                $docblock['startLine'],
+                $docblock['endLine'] - $docblock['startLine'] + 1,
+                $docblockLines
+            );
+        } else {
+            $docblockLines = [
+                '/**',
+                " * @phpstan-require-implements {$interface}",
+                ' */',
+            ];
+            array_splice($lines, $classIndex, 0, $docblockLines);
+        }
+
+        return FixResult::success(
+            $issue,
+            implode("\n", $lines),
+            sprintf('Added @phpstan-require-implements %s', $interface),
+            [sprintf('Annotated %s at line %d', $interface, $classLine)]
+        );
+    }
+
+    public function getDescription(): string
+    {
+        return 'Adds @phpstan-require-implements to traits requiring a specific interface implementation';
+    }
+
+    public function getName(): string
+    {
+        return 'RequireImplementsFixer';
+    }
+
+    private function extractInterface(string $message): ?string
+    {
+        if (preg_match('/require(?:s)?\s+implements\s+([\\\\\w]+)/i', $message, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int, mixed> $ast
+     * @return array{0: mixed, 1: int}|null
+     */
+    private function findClassLikeAtLine(array $ast, int $targetLine): ?array
+    {
+        /** @var ClassLike[] $classLikes */
+        $classLikes = $this->nodeFinder->findInstanceOf($ast, ClassLike::class);
+
+        foreach ($classLikes as $classLike) {
+            $line = $this->analyzer->getNodeLine($classLike);
+            if ($targetLine >= $line - 1 && $targetLine <= $line + 2) {
+                return [$classLike, $line];
+            }
+        }
+
+        return null;
+    }
+}
+

--- a/tests/Unit/Strategy/RequireImplementsFixerTest.php
+++ b/tests/Unit/Strategy/RequireImplementsFixerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Copyright (c) 2025 Łukasz Zychal
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpstanFixer\Tests\Unit\Strategy;
+
+use PhpstanFixer\CodeAnalysis\DocblockManipulator;
+use PhpstanFixer\CodeAnalysis\PhpFileAnalyzer;
+use PhpstanFixer\Issue;
+use PhpstanFixer\Strategy\RequireImplementsFixer;
+use PHPUnit\Framework\TestCase;
+
+final class RequireImplementsFixerTest extends TestCase
+{
+    private RequireImplementsFixer $fixer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fixer = new RequireImplementsFixer(
+            new PhpFileAnalyzer(),
+            new DocblockManipulator()
+        );
+    }
+
+    public function testAddsRequireImplementsToTrait(): void
+    {
+        $tempFile = sys_get_temp_dir() . '/require-implements-' . uniqid() . '.php';
+        $fileContent = <<<'PHP'
+<?php
+
+trait FooTrait
+{
+    public function bar() {}
+}
+PHP;
+        file_put_contents($tempFile, $fileContent);
+
+        try {
+            $issue = new Issue(
+                $tempFile,
+                3,
+                'Trait FooTrait requires implements FooContract'
+            );
+
+            $result = $this->fixer->fix($issue, $fileContent);
+
+            $this->assertTrue($result->isSuccessful());
+            $this->assertStringContainsString('@phpstan-require-implements FooContract', $result->getFixedContent());
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+
+    public function testFailsWhenAnnotationAlreadyExists(): void
+    {
+        $tempFile = sys_get_temp_dir() . '/require-implements-existing-' . uniqid() . '.php';
+        $fileContent = <<<'PHP'
+<?php
+
+/**
+ * @phpstan-require-implements FooContract
+ */
+trait FooTrait
+{
+    public function bar() {}
+}
+PHP;
+        file_put_contents($tempFile, $fileContent);
+
+        try {
+            $issue = new Issue(
+                $tempFile,
+                6,
+                'Trait FooTrait requires implements FooContract'
+            );
+
+            $result = $this->fixer->fix($issue, $fileContent);
+
+            $this->assertFalse($result->isSuccessful());
+            $this->assertStringContainsString('already exists', $result->getDescription() ?? '');
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+
+    public function testCanFixPattern(): void
+    {
+        $issue = new Issue(
+            '/tmp/file.php',
+            3,
+            'Trait FooTrait requires implements FooContract'
+        );
+
+        $this->assertTrue($this->fixer->canFix($issue));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add RequireImplementsFixer to insert `@phpstan-require-implements InterfaceName` for traits flagged by PHPStan
- extend DocblockManipulator to parse/format phpstan-require-implements
- register the fixer in default strategies and update status docs (TODO, IMPLEMENTED)
- add unit coverage for adding the annotation and for existing-tag skip

## Testing
- vendor/bin/phpunit --filter RequireImplementsFixerTest
- vendor/bin/phpunit (1 skipped as before)

## Merge order
- Intended merge order: after existing merged fixers, before upcoming ArrayOffsetTypeFixer (plan order 1/8 for remaining tasks)
