### PR TITLE
feat: add array offset type fixer

### DIFF
--- a/IMPLEMENTED_FIXERS.md
+++ b/IMPLEMENTED_FIXERS.md
@@ -108,6 +108,11 @@
 - **Naprawa:** Zmienia PHPDoc na fully-qualified name
 - **Status:** NIE zaimplementowane
 
+#### 11. ✅ ArrayOffsetTypeFixer
+- **Błąd:** \"Unknown array offset types\" / \"Missing iterable value type\"
+- **Naprawa:** Dodaje generyki do tablic (np. `array<int, string>`)
+- **Status:** Zaimplementowane
+
 ---
 
 ## 🟡 Częściowo zaimplementowane / Wymagają poprawy

--- a/TODO.md
+++ b/TODO.md
@@ -94,7 +94,7 @@ See [ROADMAP.md](ROADMAP.md) for detailed planning.
 11. **ArrayOffsetTypeFixer**
     - **Error Pattern:** "Unknown array offset types" / "Missing iterable value type"
     - **Fix:** Add generics to array types (e.g., `array<int, string>`)
-    - **Status:** Not implemented
+    - **Status:** Implemented (see ArrayOffsetTypeFixer)
     - **Priority:** Medium
     - **Reference:** PHPStan Level 5
 

--- a/src/PhpstanFixer/Command/PhpstanAutoFixCommand.php
+++ b/src/PhpstanFixer/Command/PhpstanAutoFixCommand.php
@@ -30,6 +30,7 @@ use PhpstanFixer\Strategy\PrefixedTagsFixer;
 use PhpstanFixer\Strategy\ReadonlyPropertyFixer;
 use PhpstanFixer\Strategy\RequireExtendsFixer;
 use PhpstanFixer\Strategy\RequireImplementsFixer;
+use PhpstanFixer\Strategy\ArrayOffsetTypeFixer;
 use PhpstanFixer\Strategy\UndefinedMethodFixer;
 use PhpstanFixer\Strategy\UndefinedPivotPropertyFixer;
 use PhpstanFixer\Strategy\UndefinedVariableFixer;
@@ -360,6 +361,7 @@ final class PhpstanAutoFixCommand extends Command
             new ImpureFunctionFixer($analyzer, $docblockManipulator),
             new RequireExtendsFixer($analyzer, $docblockManipulator),
             new RequireImplementsFixer($analyzer, $docblockManipulator),
+            new ArrayOffsetTypeFixer($analyzer, $docblockManipulator),
         ];
 
         return new AutoFixService($strategies, $configuration);

--- a/src/PhpstanFixer/Strategy/ArrayOffsetTypeFixer.php
+++ b/src/PhpstanFixer/Strategy/ArrayOffsetTypeFixer.php
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * Copyright (c) 2025 Łukasz Zychal
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpstanFixer\Strategy;
+
+use PhpstanFixer\CodeAnalysis\DocblockManipulator;
+use PhpstanFixer\CodeAnalysis\PhpFileAnalyzer;
+use PhpstanFixer\FixResult;
+use PhpstanFixer\Issue;
+
+/**
+ * Adds array generics (array<int, mixed>) when PHPStan reports unknown array offset types.
+ *
+ * @author Łukasz Zychal <lukasz.zychal.dev@gmail.com>
+ */
+final class ArrayOffsetTypeFixer implements FixStrategyInterface
+{
+    public function __construct(
+        private readonly PhpFileAnalyzer $analyzer,
+        private readonly DocblockManipulator $docblockManipulator
+    ) {
+    }
+
+    public function canFix(Issue $issue): bool
+    {
+        return $issue->matchesPattern('/array offset/i')
+            || $issue->matchesPattern('/offset type/i')
+            || $issue->matchesPattern('/Missing iterable value type/i');
+    }
+
+    public function fix(Issue $issue, string $fileContent): FixResult
+    {
+        if (!file_exists($issue->getFilePath())) {
+            return FixResult::failure($issue, $fileContent, 'File does not exist');
+        }
+
+        $ast = $this->analyzer->parse($fileContent);
+        if ($ast === null) {
+            return FixResult::failure($issue, $fileContent, 'Could not parse file');
+        }
+
+        $targetLine = $issue->getLine();
+        $paramName = $this->extractParamName($issue->getMessage());
+
+        $functions = $this->analyzer->getFunctions($ast);
+        $classes = $this->analyzer->getClasses($ast);
+
+        $targetFunction = null;
+        $targetMethod = null;
+
+        foreach ($functions as $function) {
+            $functionLine = $this->analyzer->getNodeLine($function);
+            if ($functionLine === $targetLine || abs($functionLine - $targetLine) <= 5) {
+                $targetFunction = $function;
+                break;
+            }
+        }
+
+        if ($targetFunction === null) {
+            foreach ($classes as $class) {
+                $methods = $this->analyzer->getMethods($class);
+                foreach ($methods as $method) {
+                    $methodLine = $this->analyzer->getNodeLine($method);
+                    if ($methodLine === $targetLine || abs($methodLine - $targetLine) <= 5) {
+                        $targetMethod = $method;
+                        break 2;
+                    }
+                }
+            }
+        }
+
+        $targetNode = $targetFunction ?? $targetMethod;
+        if ($targetNode === null) {
+            return FixResult::failure($issue, $fileContent, 'Could not find function/method near specified line');
+        }
+
+        $nodeLine = $this->analyzer->getNodeLine($targetNode);
+        $nodeIndex = $nodeLine - 1;
+        $lines = explode("\n", $fileContent);
+
+        // Determine parameter name from signature if not extracted
+        if ($paramName === null && isset($targetNode->params[0])) {
+            $paramName = '$' . $targetNode->params[0]->var->name;
+        }
+
+        if ($paramName === null) {
+            return FixResult::failure($issue, $fileContent, 'Could not determine parameter name');
+        }
+
+        $existingDocblock = $this->docblockManipulator->extractDocblock($lines, $nodeIndex);
+
+        if ($existingDocblock !== null) {
+            // If already has generic for param, fail
+            $parsed = $this->docblockManipulator->parseDocblock($existingDocblock['content']);
+            foreach ($parsed['param'] ?? [] as $param) {
+                if (($param['name'] ?? '') === $paramName) {
+                    $type = $param['type'] ?? '';
+                    if (str_contains($type, '<')) {
+                        return FixResult::failure($issue, $fileContent, 'Generic array annotation already exists');
+                    }
+                }
+            }
+
+            // Additional guard: if docblock already mentions array< for this param name as raw text
+            $rawDoc = $existingDocblock['content'];
+            if (preg_match('/@param\\s+array<[^>]+>\\s+' . preg_quote($paramName, '/') . '\\b/i', $rawDoc)) {
+                return FixResult::failure($issue, $fileContent, 'Generic array annotation already exists');
+            }
+
+            // Replace simple "@param array $param" with generic, if present
+            $updatedDocblock = $this->replaceParamArrayWithGeneric($existingDocblock['content'], $paramName);
+
+            // If no replacement happened, add annotation
+            if ($updatedDocblock === $existingDocblock['content']) {
+                $updatedDocblock = $this->docblockManipulator->addAnnotation(
+                    $existingDocblock['content'],
+                    'param',
+                    "array<int, mixed> {$paramName}"
+                );
+            }
+
+            $docblockLines = explode("\n", $updatedDocblock);
+            array_splice(
+                $lines,
+                $existingDocblock['startLine'],
+                $existingDocblock['endLine'] - $existingDocblock['startLine'] + 1,
+                $docblockLines
+            );
+        } else {
+            // Create new docblock with param generic
+            $docblock = "/**\n * @param array<int, mixed> {$paramName}\n */";
+            $docblockLines = explode("\n", $docblock);
+            array_splice($lines, $nodeIndex, 0, $docblockLines);
+        }
+
+        return FixResult::success(
+            $issue,
+            implode("\n", $lines),
+            "Added generic array type for {$paramName}",
+            ["Added @param array<int, mixed> {$paramName}"]
+        );
+    }
+
+    public function getDescription(): string
+    {
+        return 'Adds array generics for parameters when PHPStan reports unknown array offset types';
+    }
+
+    public function getName(): string
+    {
+        return 'ArrayOffsetTypeFixer';
+    }
+
+    private function extractParamName(string $message): ?string
+    {
+        if (preg_match('/\\$(\\w+)/', $message, $matches)) {
+            return '$' . $matches[1];
+        }
+
+        return null;
+    }
+
+    private function replaceParamArrayWithGeneric(string $docblockContent, string $paramName): string
+    {
+        $pattern = '/@param\\s+array\\s+' . preg_quote($paramName, '/') . '(\\b|\\s)/';
+        $replacement = '@param array<int, mixed> ' . $paramName . '$1';
+
+        return preg_replace($pattern, $replacement, $docblockContent) ?? $docblockContent;
+    }
+}
+

--- a/tests/Unit/Strategy/ArrayOffsetTypeFixerTest.php
+++ b/tests/Unit/Strategy/ArrayOffsetTypeFixerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Copyright (c) 2025 Łukasz Zychal
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpstanFixer\Tests\Unit\Strategy;
+
+use PhpstanFixer\CodeAnalysis\DocblockManipulator;
+use PhpstanFixer\CodeAnalysis\PhpFileAnalyzer;
+use PhpstanFixer\Issue;
+use PhpstanFixer\Strategy\ArrayOffsetTypeFixer;
+use PHPUnit\Framework\TestCase;
+
+final class ArrayOffsetTypeFixerTest extends TestCase
+{
+    private ArrayOffsetTypeFixer $fixer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fixer = new ArrayOffsetTypeFixer(
+            new PhpFileAnalyzer(),
+            new DocblockManipulator()
+        );
+    }
+
+    public function testAddsGenericParamWhenMissingDocblock(): void
+    {
+        $tempFile = sys_get_temp_dir() . '/array-offset-' . uniqid() . '.php';
+        $fileContent = <<<'PHP'
+<?php
+
+function take(array $items)
+{
+    return $items[0]; // line 6
+}
+PHP;
+        file_put_contents($tempFile, $fileContent);
+
+        try {
+            $issue = new Issue(
+                $tempFile,
+                6,
+                'Unknown array offset type on $items'
+            );
+
+            $result = $this->fixer->fix($issue, $fileContent);
+
+            $this->assertTrue($result->isSuccessful());
+            $this->assertStringContainsString('@param array<int, mixed> $items', $result->getFixedContent());
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+
+    public function testFailsWhenAlreadyGeneric(): void
+    {
+        $tempFile = sys_get_temp_dir() . '/array-offset-existing-' . uniqid() . '.php';
+        $fileContent = <<<'PHP'
+<?php
+
+/**
+ * @param array<int, mixed> $items
+ */
+function take(array $items)
+{
+    return $items[0]; // line 9
+}
+PHP;
+        file_put_contents($tempFile, $fileContent);
+
+        try {
+            $issue = new Issue(
+                $tempFile,
+                9,
+                'Unknown array offset type on $items'
+            );
+
+            $result = $this->fixer->fix($issue, $fileContent);
+
+            $this->assertFalse($result->isSuccessful());
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add ArrayOffsetTypeFixer to add generics (array<int, mixed>) when PHPStan reports unknown array offset types
- register fixer in default strategies; update TODO/IMPLEMENTED statuses
- add unit coverage for adding generics and skip when already generic

## Testing
- vendor/bin/phpunit --filter ArrayOffsetTypeFixerTest
- vendor/bin/phpunit (1 skipped as before)

## Merge order
- Intended merge order: after RequireImplementsFixer (plan step 2/8)
