### PR TITLE
feat: add immutable class fixer

### DIFF
--- a/src/PhpstanFixer/Strategy/ImmutableClassFixer.php
+++ b/src/PhpstanFixer/Strategy/ImmutableClassFixer.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Copyright (c) 2025 Łukasz Zychal
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpstanFixer\Strategy;
+
+use PhpstanFixer\CodeAnalysis\DocblockManipulator;
+use PhpstanFixer\CodeAnalysis\PhpFileAnalyzer;
+use PhpstanFixer\FixResult;
+use PhpstanFixer\Issue;
+
+/**
+ * Adds @immutable annotation to classes reported as immutable with properties assigned outside.
+ *
+ * @author Łukasz Zychal <lukasz.zychal.dev@gmail.com>
+ */
+final class ImmutableClassFixer implements FixStrategyInterface
+{
+    public function __construct(
+        private readonly PhpFileAnalyzer $analyzer,
+        private readonly DocblockManipulator $docblockManipulator
+    ) {
+    }
+
+    public function canFix(Issue $issue): bool
+    {
+        return $issue->matchesPattern('/immutable/i')
+            && $issue->matchesPattern('/property/i');
+    }
+
+    public function fix(Issue $issue, string $fileContent): FixResult
+    {
+        if (!file_exists($issue->getFilePath())) {
+            return FixResult::failure($issue, $fileContent, 'File does not exist');
+        }
+
+        $ast = $this->analyzer->parse($fileContent);
+        if ($ast === null) {
+            return FixResult::failure($issue, $fileContent, 'Could not parse file');
+        }
+
+        $classes = $this->analyzer->getClasses($ast);
+        $targetLine = $issue->getLine();
+        $targetClass = null;
+        $classLine = null;
+
+        foreach ($classes as $class) {
+            $classStartLine = $this->analyzer->getNodeLine($class);
+            // rough range
+            if ($targetLine >= $classStartLine && $targetLine <= $classStartLine + 500) {
+                $targetClass = $class;
+                $classLine = $classStartLine;
+                break;
+            }
+        }
+
+        if ($targetClass === null || $classLine === null) {
+            return FixResult::failure($issue, $fileContent, 'Could not find class for immutable annotation');
+        }
+
+        $lines = explode("\n", $fileContent);
+        $classIndex = $classLine - 1;
+        $docblock = $this->docblockManipulator->extractDocblock($lines, $classIndex);
+
+        if ($docblock !== null && str_contains($docblock['content'], '@immutable')) {
+            return FixResult::failure($issue, $fileContent, '@immutable already exists');
+        }
+
+        if ($docblock !== null) {
+            $updated = $this->docblockManipulator->addAnnotation($docblock['content'], 'immutable', '');
+            $docblockLines = explode("\n", $updated);
+            array_splice(
+                $lines,
+                $docblock['startLine'],
+                $docblock['endLine'] - $docblock['startLine'] + 1,
+                $docblockLines
+            );
+        } else {
+            $docblockLines = [
+                '/**',
+                ' * @immutable',
+                ' */',
+            ];
+            array_splice($lines, $classIndex, 0, $docblockLines);
+        }
+
+        return FixResult::success(
+            $issue,
+            implode("\n", $lines),
+            'Added @immutable to class',
+            ['Added @immutable annotation']
+        );
+    }
+
+    public function getDescription(): string
+    {
+        return 'Adds @immutable annotation to immutable classes with external assignments.';
+    }
+
+    public function getName(): string
+    {
+        return 'ImmutableClassFixer';
+    }
+}
+

--- a/tests/Unit/Strategy/ImmutableClassFixerTest.php
+++ b/tests/Unit/Strategy/ImmutableClassFixerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Copyright (c) 2025 Łukasz Zychal
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpstanFixer\Tests\Unit\Strategy;
+
+use PhpstanFixer\CodeAnalysis\DocblockManipulator;
+use PhpstanFixer\CodeAnalysis\PhpFileAnalyzer;
+use PhpstanFixer\Issue;
+use PhpstanFixer\Strategy\ImmutableClassFixer;
+use PHPUnit\Framework\TestCase;
+
+final class ImmutableClassFixerTest extends TestCase
+{
+    private ImmutableClassFixer $fixer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fixer = new ImmutableClassFixer(
+            new PhpFileAnalyzer(),
+            new DocblockManipulator()
+        );
+    }
+
+    public function testAddsImmutableToClass(): void
+    {
+        $tempFile = sys_get_temp_dir() . '/immutable-class-' . uniqid() . '.php';
+        $fileContent = <<<'PHP'
+<?php
+
+class Foo
+{
+    public int $x;
+}
+PHP;
+        file_put_contents($tempFile, $fileContent);
+
+        try {
+            $issue = new Issue(
+                $tempFile,
+                4,
+                'Class Foo is immutable and property $x is assigned outside'
+            );
+
+            $result = $this->fixer->fix($issue, $fileContent);
+
+            $this->assertTrue($result->isSuccessful());
+            $this->assertStringContainsString('@immutable', $result->getFixedContent());
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+
+    public function testSkipsWhenAlreadyImmutable(): void
+    {
+        $tempFile = sys_get_temp_dir() . '/immutable-existing-' . uniqid() . '.php';
+        $fileContent = <<<'PHP'
+<?php
+
+/**
+ * @immutable
+ */
+class Foo
+{
+    public int $x;
+}
+PHP;
+        file_put_contents($tempFile, $fileContent);
+
+        try {
+            $issue = new Issue(
+                $tempFile,
+                8,
+                'Class Foo is immutable and property $x is assigned outside'
+            );
+
+            $result = $this->fixer->fix($issue, $fileContent);
+
+            $this->assertFalse($result->isSuccessful());
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add ImmutableClassFixer to apply `@immutable` to classes flagged for external assignments
- unit coverage for adding annotation and skipping when present

## Testing
- vendor/bin/phpunit --filter ImmutableClassFixerTest
- vendor/bin/phpunit (1 skipped as before)

## Merge order
- Intended merge order: after IterableValueTypeFixer (plan step 4/8)
