### PR TITLE
feat: add sealed class fixer

### DIFF
--- a/src/PhpstanFixer/CodeAnalysis/DocblockManipulator.php
+++ b/src/PhpstanFixer/CodeAnalysis/DocblockManipulator.php
@@ -109,6 +109,7 @@ final class DocblockManipulator
             'phpstan-pure' => [],
             'phpstan-require-extends' => [],
             'phpstan-require-implements' => [],
+            'phpstan-sealed' => [],
         ];
 
         // Remove /** and */ markers
@@ -250,6 +251,16 @@ final class DocblockManipulator
                     ];
                 }
                 break;
+
+            case 'phpstan-sealed':
+                // @phpstan-sealed Class1|Class2
+                if (preg_match('/^([\\\\\w|]+)(?:\s+(.+))?$/', $value, $matches)) {
+                    return [
+                        'classList' => $matches[1],
+                        'description' => $matches[2] ?? null,
+                    ];
+                }
+                break;
         }
 
         return ['raw' => $value];
@@ -351,6 +362,7 @@ final class DocblockManipulator
             'phpstan-pure',
             'phpstan-require-extends',
             'phpstan-require-implements',
+            'phpstan-sealed',
             'throws',
             'var',
             'property',
@@ -482,6 +494,13 @@ final class DocblockManipulator
 
             case 'phpstan-require-implements':
                 $result = $data['className'] ?? '';
+                if (isset($data['description'])) {
+                    $result .= ' ' . $data['description'];
+                }
+                return trim($result);
+
+            case 'phpstan-sealed':
+                $result = $data['classList'] ?? '';
                 if (isset($data['description'])) {
                     $result .= ' ' . $data['description'];
                 }

--- a/src/PhpstanFixer/Strategy/SealedClassFixer.php
+++ b/src/PhpstanFixer/Strategy/SealedClassFixer.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * Copyright (c) 2025 Łukasz Zychal
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpstanFixer\Strategy;
+
+use PhpstanFixer\CodeAnalysis\DocblockManipulator;
+use PhpstanFixer\CodeAnalysis\PhpFileAnalyzer;
+use PhpstanFixer\FixResult;
+use PhpstanFixer\Issue;
+
+/**
+ * Adds @phpstan-sealed Class1|Class2 when a class extends a sealed class.
+ *
+ * @author Łukasz Zychal <lukasz.zychal.dev@gmail.com>
+ */
+final class SealedClassFixer implements FixStrategyInterface
+{
+    public function __construct(
+        private readonly PhpFileAnalyzer $analyzer,
+        private readonly DocblockManipulator $docblockManipulator
+    ) {
+    }
+
+    public function canFix(Issue $issue): bool
+    {
+        return $issue->matchesPattern('/sealed class/i');
+    }
+
+    public function fix(Issue $issue, string $fileContent): FixResult
+    {
+        if (!file_exists($issue->getFilePath())) {
+            return FixResult::failure($issue, $fileContent, 'File does not exist');
+        }
+
+        $ast = $this->analyzer->parse($fileContent);
+        if ($ast === null) {
+            return FixResult::failure($issue, $fileContent, 'Could not parse file');
+        }
+
+        $targetLine = $issue->getLine();
+        $classes = $this->analyzer->getClasses($ast);
+        $targetClass = null;
+        $classLine = null;
+        $sealedBase = $this->extractSealedBase($issue->getMessage());
+
+        foreach ($classes as $class) {
+            $classStartLine = $this->analyzer->getNodeLine($class);
+            if ($targetLine >= $classStartLine && $targetLine <= $classStartLine + 500) {
+                $targetClass = $class;
+                $classLine = $classStartLine;
+                break;
+            }
+        }
+
+        if ($targetClass === null || $classLine === null || $sealedBase === null) {
+            return FixResult::failure($issue, $fileContent, 'Could not determine class or sealed base');
+        }
+
+        $lines = explode("\n", $fileContent);
+        $classIndex = $classLine - 1;
+        $docblock = $this->docblockManipulator->extractDocblock($lines, $classIndex);
+
+        if ($docblock !== null) {
+            $parsed = $this->docblockManipulator->parseDocblock($docblock['content']);
+            $sealedEntries = $parsed['phpstan-sealed'] ?? [];
+            if (!empty($sealedEntries)) {
+                return FixResult::failure($issue, $fileContent, '@phpstan-sealed already exists');
+            }
+
+            $updated = $this->docblockManipulator->addAnnotation(
+                $docblock['content'],
+                'phpstan-sealed',
+                $sealedBase
+            );
+
+            $docblockLines = explode("\n", $updated);
+            array_splice(
+                $lines,
+                $docblock['startLine'],
+                $docblock['endLine'] - $docblock['startLine'] + 1,
+                $docblockLines
+            );
+        } else {
+            $docblockLines = [
+                '/**',
+                " * @phpstan-sealed {$sealedBase}",
+                ' */',
+            ];
+            array_splice($lines, $classIndex, 0, $docblockLines);
+        }
+
+        return FixResult::success(
+            $issue,
+            implode("\n", $lines),
+            "Added @phpstan-sealed {$sealedBase}",
+            ["Added @phpstan-sealed {$sealedBase} at class"]
+        );
+    }
+
+    public function getDescription(): string
+    {
+        return 'Adds @phpstan-sealed annotation when extending sealed classes.';
+    }
+
+    public function getName(): string
+    {
+        return 'SealedClassFixer';
+    }
+
+    private function extractSealedBase(string $message): ?string
+    {
+        if (preg_match('/sealed class\\s+([\\\\\\w]+)/i', $message, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+}
+

--- a/tests/Unit/Strategy/SealedClassFixerTest.php
+++ b/tests/Unit/Strategy/SealedClassFixerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Copyright (c) 2025 Łukasz Zychal
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpstanFixer\Tests\Unit\Strategy;
+
+use PhpstanFixer\CodeAnalysis\DocblockManipulator;
+use PhpstanFixer\CodeAnalysis\PhpFileAnalyzer;
+use PhpstanFixer\Issue;
+use PhpstanFixer\Strategy\SealedClassFixer;
+use PHPUnit\Framework\TestCase;
+
+final class SealedClassFixerTest extends TestCase
+{
+    private SealedClassFixer $fixer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fixer = new SealedClassFixer(
+            new PhpFileAnalyzer(),
+            new DocblockManipulator()
+        );
+    }
+
+    public function testAddsSealedAnnotation(): void
+    {
+        $tempFile = sys_get_temp_dir() . '/sealed-class-' . uniqid() . '.php';
+        $fileContent = <<<'PHP'
+<?php
+
+class Foo extends Base
+{
+}
+PHP;
+        file_put_contents($tempFile, $fileContent);
+
+        try {
+            $issue = new Issue(
+                $tempFile,
+                3,
+                'Class Foo extends sealed class Base'
+            );
+
+            $result = $this->fixer->fix($issue, $fileContent);
+
+            $this->assertTrue($result->isSuccessful());
+            $this->assertStringContainsString('@phpstan-sealed', $result->getFixedContent());
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+
+    public function testSkipsWhenAlreadySealed(): void
+    {
+        $tempFile = sys_get_temp_dir() . '/sealed-existing-' . uniqid() . '.php';
+        $fileContent = <<<'PHP'
+<?php
+
+/**
+ * @phpstan-sealed Base|Other
+ */
+class Foo extends Base
+{
+}
+PHP;
+        file_put_contents($tempFile, $fileContent);
+
+        try {
+            $issue = new Issue(
+                $tempFile,
+                7,
+                'Class Foo extends sealed class Base'
+            );
+
+            $result = $this->fixer->fix($issue, $fileContent);
+
+            $this->assertFalse($result->isSuccessful());
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add SealedClassFixer to insert `@phpstan-sealed Class1|Class2` when extending sealed classes
- DocblockManipulator now parses/formats phpstan-sealed
- unit coverage for adding annotation and skipping when already present

## Testing
- vendor/bin/phpunit --filter SealedClassFixerTest
- vendor/bin/phpunit (1 skipped as before)

## Merge order
- Intended merge order: after ImmutableClassFixer (plan step 5/8)
