### PR TITLE
feat: add internal annotation fixer

### DIFF
--- a/IMPLEMENTED_FIXERS.md
+++ b/IMPLEMENTED_FIXERS.md
@@ -63,10 +63,10 @@
 - **Naprawa:** Dodaje `@mixin ClassName` na klasie
 - **Status:** NIE zaimplementowane
 
-#### 2. ❌ InternalAnnotationFixer
+#### 2. ✅ InternalAnnotationFixer
 - **Błąd:** "Access to internal element"
 - **Naprawa:** Dodaje `@internal` tag
-- **Status:** NIE zaimplementowane (rzadko potrzebne automatycznie)
+- **Status:** Zaimplementowane (rzadko potrzebne automatycznie)
 
 #### 3. ✅ ImpureFunctionFixer
 - **Błąd:** Functions that may return different values

--- a/TODO.md
+++ b/TODO.md
@@ -69,7 +69,7 @@ See [ROADMAP.md](ROADMAP.md) for detailed planning.
 ### 9. InternalAnnotationFixer
 - **Error Pattern:** Access to internal element
 - **Fix:** Add `@internal` tag (rarely needed automatically)
-- **Status:** Not implemented
+- **Status:** Implemented (see InternalAnnotationFixer)
 - **Reference:** PHPStan docs - Internal symbols section
 
 ### 10. ClassesNamedAfterInternalTypesFixer

--- a/src/PhpstanFixer/Command/PhpstanAutoFixCommand.php
+++ b/src/PhpstanFixer/Command/PhpstanAutoFixCommand.php
@@ -32,6 +32,7 @@ use PhpstanFixer\Strategy\RequireExtendsFixer;
 use PhpstanFixer\Strategy\RequireImplementsFixer;
 use PhpstanFixer\Strategy\ArrayOffsetTypeFixer;
 use PhpstanFixer\Strategy\IterableValueTypeFixer;
+use PhpstanFixer\Strategy\InternalAnnotationFixer;
 use PhpstanFixer\Strategy\UndefinedMethodFixer;
 use PhpstanFixer\Strategy\UndefinedPivotPropertyFixer;
 use PhpstanFixer\Strategy\UndefinedVariableFixer;
@@ -364,6 +365,7 @@ final class PhpstanAutoFixCommand extends Command
             new RequireImplementsFixer($analyzer, $docblockManipulator),
             new ArrayOffsetTypeFixer($analyzer, $docblockManipulator),
             new IterableValueTypeFixer($analyzer, $docblockManipulator),
+            new InternalAnnotationFixer($analyzer, $docblockManipulator),
         ];
 
         return new AutoFixService($strategies, $configuration);

--- a/src/PhpstanFixer/Strategy/InternalAnnotationFixer.php
+++ b/src/PhpstanFixer/Strategy/InternalAnnotationFixer.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Copyright (c) 2025 Łukasz Zychal
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpstanFixer\Strategy;
+
+use PhpstanFixer\CodeAnalysis\DocblockManipulator;
+use PhpstanFixer\CodeAnalysis\PhpFileAnalyzer;
+use PhpstanFixer\FixResult;
+use PhpstanFixer\Issue;
+
+/**
+ * Adds @internal annotation when accessing internal elements.
+ *
+ * @author Łukasz Zychal <lukasz.zychal.dev@gmail.com>
+ */
+final class InternalAnnotationFixer implements FixStrategyInterface
+{
+    public function __construct(
+        private readonly PhpFileAnalyzer $analyzer,
+        private readonly DocblockManipulator $docblockManipulator
+    ) {
+    }
+
+    public function canFix(Issue $issue): bool
+    {
+        return $issue->matchesPattern('/internal/i');
+    }
+
+    public function fix(Issue $issue, string $fileContent): FixResult
+    {
+        if (!file_exists($issue->getFilePath())) {
+            return FixResult::failure($issue, $fileContent, 'File does not exist');
+        }
+
+        $ast = $this->analyzer->parse($fileContent);
+        if ($ast === null) {
+            return FixResult::failure($issue, $fileContent, 'Could not parse file');
+        }
+
+        $classes = $this->analyzer->getClasses($ast);
+        $targetLine = $issue->getLine();
+        $targetClass = null;
+        $classLine = null;
+
+        foreach ($classes as $class) {
+            $classStartLine = $this->analyzer->getNodeLine($class);
+            if ($targetLine >= $classStartLine && $targetLine <= $classStartLine + 500) {
+                $targetClass = $class;
+                $classLine = $classStartLine;
+                break;
+            }
+        }
+
+        if ($targetClass === null || $classLine === null) {
+            return FixResult::failure($issue, $fileContent, 'Could not find class for @internal');
+        }
+
+        $lines = explode("\n", $fileContent);
+        $classIndex = $classLine - 1;
+        $docblock = $this->docblockManipulator->extractDocblock($lines, $classIndex);
+
+        if ($docblock !== null && str_contains($docblock['content'], '@internal')) {
+            return FixResult::failure($issue, $fileContent, '@internal already exists');
+        }
+
+        if ($docblock !== null) {
+            $updated = $this->docblockManipulator->addAnnotation($docblock['content'], 'internal', '');
+            $docblockLines = explode("\n", $updated);
+            array_splice(
+                $lines,
+                $docblock['startLine'],
+                $docblock['endLine'] - $docblock['startLine'] + 1,
+                $docblockLines
+            );
+        } else {
+            $docblockLines = [
+                '/**',
+                ' * @internal',
+                ' */',
+            ];
+            array_splice($lines, $classIndex, 0, $docblockLines);
+        }
+
+        return FixResult::success(
+            $issue,
+            implode("\n", $lines),
+            'Added @internal to class',
+            ['Added @internal annotation']
+        );
+    }
+
+    public function getDescription(): string
+    {
+        return 'Adds @internal annotation for internal elements.';
+    }
+
+    public function getName(): string
+    {
+        return 'InternalAnnotationFixer';
+    }
+}
+

--- a/tests/Unit/Strategy/InternalAnnotationFixerTest.php
+++ b/tests/Unit/Strategy/InternalAnnotationFixerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Copyright (c) 2025 Łukasz Zychal
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpstanFixer\Tests\Unit\Strategy;
+
+use PhpstanFixer\CodeAnalysis\DocblockManipulator;
+use PhpstanFixer\CodeAnalysis\PhpFileAnalyzer;
+use PhpstanFixer\Issue;
+use PhpstanFixer\Strategy\InternalAnnotationFixer;
+use PHPUnit\Framework\TestCase;
+
+final class InternalAnnotationFixerTest extends TestCase
+{
+    private InternalAnnotationFixer $fixer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fixer = new InternalAnnotationFixer(
+            new PhpFileAnalyzer(),
+            new DocblockManipulator()
+        );
+    }
+
+    public function testAddsInternalToClass(): void
+    {
+        $tempFile = sys_get_temp_dir() . '/internal-class-' . uniqid() . '.php';
+        $fileContent = <<<'PHP'
+<?php
+
+class Foo
+{
+}
+PHP;
+        file_put_contents($tempFile, $fileContent);
+
+        try {
+            $issue = new Issue(
+                $tempFile,
+                3,
+                'Access to internal class Foo'
+            );
+
+            $result = $this->fixer->fix($issue, $fileContent);
+
+            $this->assertTrue($result->isSuccessful());
+            $this->assertStringContainsString('@internal', $result->getFixedContent());
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+
+    public function testSkipsWhenAlreadyInternal(): void
+    {
+        $tempFile = sys_get_temp_dir() . '/internal-existing-' . uniqid() . '.php';
+        $fileContent = <<<'PHP'
+<?php
+
+/**
+ * @internal
+ */
+class Foo
+{
+}
+PHP;
+        file_put_contents($tempFile, $fileContent);
+
+        try {
+            $issue = new Issue(
+                $tempFile,
+                7,
+                'Access to internal class Foo'
+            );
+
+            $result = $this->fixer->fix($issue, $fileContent);
+
+            $this->assertFalse($result->isSuccessful());
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add InternalAnnotationFixer to insert `@internal` when PHPStan reports access to internal elements
- register fixer in default strategies; update TODO/IMPLEMENTED statuses
- add unit coverage for adding @internal and skipping when present

## Testing
- vendor/bin/phpunit --filter InternalAnnotationFixerTest
- vendor/bin/phpunit (1 skipped as before)

## Merge order
- Intended merge order: after SealedClassFixer (plan step 6/8)
