### PR TITLE
feat: add classes named after internal types fixer

### DIFF
--- a/IMPLEMENTED_FIXERS.md
+++ b/IMPLEMENTED_FIXERS.md
@@ -103,7 +103,12 @@
 - **Naprawa:** Dodaje `@phpstan-param`, `@phpstan-return` obok standardowych tagów
 - **Status:** Zaimplementowane
 
-#### 11. ✅ ArrayOffsetTypeFixer
+#### 11. ✅ ClassesNamedAfterInternalTypesFixer
+- **Błąd:** Konflikt nazw klas z wewnętrznymi typami PHP (Resource, Double, Number)
+- **Naprawa:** Zmienia PHPDoc na fully-qualified name
+- **Status:** Zaimplementowane
+
+#### 12. ✅ ArrayOffsetTypeFixer
 - **Błąd:** \"Unknown array offset types\" / \"Missing iterable value type\"
 - **Naprawa:** Dodaje generyki do tablic (np. `array<int, string>`)
 - **Status:** Zaimplementowane

--- a/TODO.md
+++ b/TODO.md
@@ -75,7 +75,7 @@ See [ROADMAP.md](ROADMAP.md) for detailed planning.
 ### 10. ClassesNamedAfterInternalTypesFixer
 - **Error Pattern:** Class name conflict with PHP internal types (Resource, Double, Number)
 - **Fix:** Change PHPDoc to use fully-qualified name
-- **Status:** Not implemented
+- **Status:** Implemented (see ClassesNamedAfterInternalTypesFixer)
 - **Reference:** PHPStan docs - Classes named after internal PHP types section
 
 ## Improvements Needed

--- a/src/PhpstanFixer/Command/PhpstanAutoFixCommand.php
+++ b/src/PhpstanFixer/Command/PhpstanAutoFixCommand.php
@@ -33,6 +33,7 @@ use PhpstanFixer\Strategy\RequireImplementsFixer;
 use PhpstanFixer\Strategy\ArrayOffsetTypeFixer;
 use PhpstanFixer\Strategy\IterableValueTypeFixer;
 use PhpstanFixer\Strategy\InternalAnnotationFixer;
+use PhpstanFixer\Strategy\ClassesNamedAfterInternalTypesFixer;
 use PhpstanFixer\Strategy\UndefinedMethodFixer;
 use PhpstanFixer\Strategy\UndefinedPivotPropertyFixer;
 use PhpstanFixer\Strategy\UndefinedVariableFixer;
@@ -366,6 +367,7 @@ final class PhpstanAutoFixCommand extends Command
             new ArrayOffsetTypeFixer($analyzer, $docblockManipulator),
             new IterableValueTypeFixer($analyzer, $docblockManipulator),
             new InternalAnnotationFixer($analyzer, $docblockManipulator),
+            new ClassesNamedAfterInternalTypesFixer(),
         ];
 
         return new AutoFixService($strategies, $configuration);

--- a/src/PhpstanFixer/Strategy/ClassesNamedAfterInternalTypesFixer.php
+++ b/src/PhpstanFixer/Strategy/ClassesNamedAfterInternalTypesFixer.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Copyright (c) 2025 Łukasz Zychal
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpstanFixer\Strategy;
+
+use PhpstanFixer\FixResult;
+use PhpstanFixer\Issue;
+
+/**
+ * Adjusts PHPDoc to use fully-qualified names when class names conflict with internal types.
+ *
+ * @author Łukasz Zychal <lukasz.zychal.dev@gmail.com>
+ */
+final class ClassesNamedAfterInternalTypesFixer implements FixStrategyInterface
+{
+    /** @var string[] */
+    private array $internalTypes = ['Resource', 'Double', 'Number'];
+
+    public function canFix(Issue $issue): bool
+    {
+        return $issue->matchesPattern('/internal/i')
+            && $this->containsInternalTypeName($issue->getMessage());
+    }
+
+    public function fix(Issue $issue, string $fileContent): FixResult
+    {
+        $type = $this->extractInternalType($issue->getMessage());
+        if ($type === null) {
+            return FixResult::failure($issue, $fileContent, 'Could not extract internal type');
+        }
+
+        $lines = explode("\n", $fileContent);
+        $updated = false;
+
+        foreach ($lines as $idx => $line) {
+            if (str_contains($line, '@')) {
+                $newLine = preg_replace(
+                    '/@([a-zA-Z]+)\s+' . preg_quote($type, '/') . '\b/',
+                    '@$1 \\' . $type,
+                    $line
+                );
+                if ($newLine !== null && $newLine !== $line) {
+                    $lines[$idx] = $newLine;
+                    $updated = true;
+                }
+            }
+        }
+
+        if (!$updated) {
+            return FixResult::failure($issue, $fileContent, 'No matching annotation to adjust');
+        }
+
+        return FixResult::success(
+            $issue,
+            implode("\n", $lines),
+            "Adjusted internal type {$type} to fully-qualified",
+            ["Replaced {$type} with \\{$type} in PHPDoc"]
+        );
+    }
+
+    public function getDescription(): string
+    {
+        return 'Uses fully-qualified names in PHPDoc for classes named after internal PHP types';
+    }
+
+    public function getName(): string
+    {
+        return 'ClassesNamedAfterInternalTypesFixer';
+    }
+
+    private function containsInternalTypeName(string $message): bool
+    {
+        foreach ($this->internalTypes as $type) {
+            if (stripos($message, $type) !== false) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function extractInternalType(string $message): ?string
+    {
+        foreach ($this->internalTypes as $type) {
+            if (stripos($message, $type) !== false) {
+                return $type;
+            }
+        }
+        return null;
+    }
+}
+

--- a/tests/Unit/Strategy/ClassesNamedAfterInternalTypesFixerTest.php
+++ b/tests/Unit/Strategy/ClassesNamedAfterInternalTypesFixerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Copyright (c) 2025 Łukasz Zychal
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpstanFixer\Tests\Unit\Strategy;
+
+use PhpstanFixer\Issue;
+use PhpstanFixer\Strategy\ClassesNamedAfterInternalTypesFixer;
+use PHPUnit\Framework\TestCase;
+
+final class ClassesNamedAfterInternalTypesFixerTest extends TestCase
+{
+    private ClassesNamedAfterInternalTypesFixer $fixer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fixer = new ClassesNamedAfterInternalTypesFixer();
+    }
+
+    public function testAdjustsInternalTypeInDocblock(): void
+    {
+        $tempFile = sys_get_temp_dir() . '/internal-type-' . uniqid() . '.php';
+        $fileContent = <<<'PHP'
+<?php
+
+/**
+ * @param Resource $value
+ */
+function foo($value)
+{
+    return $value; // line 8
+}
+PHP;
+        file_put_contents($tempFile, $fileContent);
+
+        try {
+            $issue = new Issue(
+                $tempFile,
+                8,
+                'Class Resource is internal'
+            );
+
+            $result = $this->fixer->fix($issue, $fileContent);
+
+            $this->assertTrue($result->isSuccessful());
+            $this->assertStringContainsString('@param \\Resource $value', $result->getFixedContent());
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+
+    public function testSkipsWhenAlreadyQualified(): void
+    {
+        $tempFile = sys_get_temp_dir() . '/internal-type-existing-' . uniqid() . '.php';
+        $fileContent = <<<'PHP'
+<?php
+
+/**
+ * @param \Resource $value
+ */
+function foo($value)
+{
+    return $value; // line 9
+}
+PHP;
+        file_put_contents($tempFile, $fileContent);
+
+        try {
+            $issue = new Issue(
+                $tempFile,
+                9,
+                'Class Resource is internal'
+            );
+
+            $result = $this->fixer->fix($issue, $fileContent);
+
+            $this->assertFalse($result->isSuccessful());
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add ClassesNamedAfterInternalTypesFixer to adjust PHPDoc to fully-qualified names when class names conflict with internal PHP types
- register fixer in default strategies; update TODO/IMPLEMENTED statuses
- add unit coverage for adjusting annotations and skipping when already qualified

## Testing
- vendor/bin/phpunit --filter ClassesNamedAfterInternalTypesFixerTest
- vendor/bin/phpunit (1 skipped as before)

## Merge order
- Intended merge order: after InternalAnnotationFixer (plan step 7/8)
