### PR TITLE
feat: register immutable and sealed fixers

### DIFF
--- a/IMPLEMENTED_FIXERS.md
+++ b/IMPLEMENTED_FIXERS.md
@@ -88,15 +88,15 @@
 - **Naprawa:** Dodaje `@readonly` tag na property
 - **Status:** NIE zaimplementowane
 
-#### 7. ❌ ImmutableClassFixer
+#### 7. ✅ ImmutableClassFixer
 - **Błąd:** Property assigned outside of immutable class
 - **Naprawa:** Dodaje `@immutable` lub `@readonly` na klasie
-- **Status:** NIE zaimplementowane
+- **Status:** Zaimplementowane
 
-#### 8. ❌ SealedClassFixer
+#### 8. ✅ SealedClassFixer
 - **Błąd:** Class extends sealed class (PHPStan 2.1.18+)
 - **Naprawa:** Dodaje `@phpstan-sealed Class1|Class2`
-- **Status:** NIE zaimplementowane
+- **Status:** Zaimplementowane
 
 #### 9. ✅ PrefixedTagsFixer
 - **Błąd:** Advanced types not understood by IDEs

--- a/TODO.md
+++ b/TODO.md
@@ -63,7 +63,7 @@ See [ROADMAP.md](ROADMAP.md) for detailed planning.
 ### 8. SealedClassFixer
 - **Error Pattern:** Class extends sealed class (PHPStan 2.1.18+)
 - **Fix:** Add `@phpstan-sealed Class1|Class2` tag
-- **Status:** Not implemented
+- **Status:** Implemented (see SealedClassFixer)
 - **Reference:** PHPStan docs - Sealed classes section
 
 ### 9. InternalAnnotationFixer

--- a/src/PhpstanFixer/Command/PhpstanAutoFixCommand.php
+++ b/src/PhpstanFixer/Command/PhpstanAutoFixCommand.php
@@ -28,6 +28,8 @@ use PhpstanFixer\Strategy\MissingUseStatementFixer;
 use PhpstanFixer\Strategy\MixinFixer;
 use PhpstanFixer\Strategy\PrefixedTagsFixer;
 use PhpstanFixer\Strategy\ReadonlyPropertyFixer;
+use PhpstanFixer\Strategy\SealedClassFixer;
+use PhpstanFixer\Strategy\ImmutableClassFixer;
 use PhpstanFixer\Strategy\RequireExtendsFixer;
 use PhpstanFixer\Strategy\RequireImplementsFixer;
 use PhpstanFixer\Strategy\ArrayOffsetTypeFixer;
@@ -363,6 +365,8 @@ final class PhpstanAutoFixCommand extends Command
             new MixinFixer($analyzer, $docblockManipulator),
             new PrefixedTagsFixer($analyzer, $docblockManipulator),
             new ImpureFunctionFixer($analyzer, $docblockManipulator),
+            new ImmutableClassFixer($analyzer, $docblockManipulator),
+            new SealedClassFixer($analyzer, $docblockManipulator),
             new RequireExtendsFixer($analyzer, $docblockManipulator),
             new RequireImplementsFixer($analyzer, $docblockManipulator),
             new ArrayOffsetTypeFixer($analyzer, $docblockManipulator),


### PR DESCRIPTION
## Summary
- register ImmutableClassFixer and SealedClassFixer in default strategies
- update TODO/IMPLEMENTED statuses

## Testing
- vendor/bin/phpunit --filter ImmutableClassFixerTest
- vendor/bin/phpunit --filter SealedClassFixerTest
- vendor/bin/phpunit (1 skipped as before)

## Merge order
- Can merge after existing PR chain; this just activates already-implemented fixers
