### PR TITLE
feat: validate configuration actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ default:
 - **`ignore`** - Don't fix and don't display the error (silent ignore)
 - **`report`** - Don't fix, but display in original PHPStan format
 
+Validation: configuration is validated on load. Invalid actions (anything other than `fix`, `ignore`, `report`) or malformed rule entries will stop execution with a clear error message.
+
 **Using Configuration:**
 
 ```bash

--- a/tests/Unit/Configuration/ConfigurationLoaderTest.php
+++ b/tests/Unit/Configuration/ConfigurationLoaderTest.php
@@ -192,6 +192,66 @@ YAML;
         $this->loader->loadFromFile($filePath);
     }
 
+    public function testThrowsWhenRuleHasInvalidAction(): void
+    {
+        $jsonContent = <<<'JSON'
+{
+  "rules": {
+    "Some pattern": {
+      "action": "skip"
+    }
+  }
+}
+JSON;
+
+        $filePath = $this->tempDir . '/phpstan-fixer.json';
+        file_put_contents($filePath, $jsonContent);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Invalid action "skip" for pattern "Some pattern"');
+
+        $this->loader->loadFromFile($filePath);
+    }
+
+    public function testThrowsWhenRuleMissingAction(): void
+    {
+        $jsonContent = <<<'JSON'
+{
+  "rules": {
+    "Some pattern": {
+      "note": "missing action"
+    }
+  }
+}
+JSON;
+
+        $filePath = $this->tempDir . '/phpstan-fixer.json';
+        file_put_contents($filePath, $jsonContent);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Rule for pattern "Some pattern" must be a string action or object with "action"');
+
+        $this->loader->loadFromFile($filePath);
+    }
+
+    public function testThrowsWhenDefaultActionIsInvalid(): void
+    {
+        $jsonContent = <<<'JSON'
+{
+  "rules": {},
+  "default": "skip"
+}
+JSON;
+
+        $filePath = $this->tempDir . '/phpstan-fixer.json';
+        file_put_contents($filePath, $jsonContent);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Invalid action "skip" for pattern "default"');
+
+        $this->loader->loadFromFile($filePath);
+    }
+
     private function removeDirectory(string $dir): void
     {
         if (!is_dir($dir)) {


### PR DESCRIPTION
## Summary
- validate configuration actions (fix/ignore/report) when loading config
- provide clear errors for malformed rule entries and defaults
- document validation behavior in README

## Testing
- vendor/bin/phpunit --filter ConfigurationLoaderTest