### PR TITLE
feat: add custom fixers support (v1.2.0)

### DIFF
--- a/V1.2.0_IMPLEMENTATION_PLAN.md
+++ b/V1.2.0_IMPLEMENTATION_PLAN.md
@@ -62,7 +62,7 @@
 - [x] Whitelist/Blacklist
 
 **Sprint 3:**
-- [ ] Custom fixers
+- [x] Custom fixers
 - [ ] Better type inference (podstawowa wersja)
 
 **Sprint 4:**

--- a/src/PhpstanFixer/Configuration/Configuration.php
+++ b/src/PhpstanFixer/Configuration/Configuration.php
@@ -26,6 +26,7 @@ final class Configuration
      * @param array<string, int> $fixerPriorities Map of fixer names to priorities
      * @param array<string> $includePaths List of paths/patterns to include
      * @param array<string> $excludePaths List of paths/patterns to exclude
+     * @param array<string> $customFixers List of custom fixer class names (FQN)
      */
     public function __construct(
         private readonly array $rules = [],
@@ -34,7 +35,8 @@ final class Configuration
         private readonly array $disabledFixers = [],
         private readonly array $fixerPriorities = [],
         private readonly array $includePaths = [],
-        private readonly array $excludePaths = []
+        private readonly array $excludePaths = [],
+        private readonly array $customFixers = []
     ) {
     }
 
@@ -215,6 +217,16 @@ final class Configuration
 
         // Otherwise, path must match at least one include pattern
         return PathFilter::matchesAny($filePath, $this->includePaths);
+    }
+
+    /**
+     * Get list of custom fixer class names (FQN).
+     *
+     * @return array<string> List of fully qualified class names
+     */
+    public function getCustomFixers(): array
+    {
+        return $this->customFixers;
     }
 }
 

--- a/src/PhpstanFixer/Configuration/ConfigurationLoader.php
+++ b/src/PhpstanFixer/Configuration/ConfigurationLoader.php
@@ -212,6 +212,15 @@ final class ConfigurationLoader
             $excludePaths = $this->extractStringArray($data['exclude_paths'], 'exclude_paths');
         }
 
+        // Parse custom_fixers
+        $customFixers = [];
+        if (isset($data['custom_fixers'])) {
+            if (!is_array($data['custom_fixers'])) {
+                throw new \RuntimeException('Configuration "custom_fixers" must be an array.');
+            }
+            $customFixers = $this->extractStringArray($data['custom_fixers'], 'custom_fixers');
+        }
+
         return new Configuration(
             $rules,
             $this->createRule('default', $defaultAction),
@@ -219,7 +228,8 @@ final class ConfigurationLoader
             $disabledFixers,
             $fixerPriorities,
             $includePaths,
-            $excludePaths
+            $excludePaths,
+            $customFixers
         );
     }
 

--- a/tests/Feature/CustomFixerTest.php
+++ b/tests/Feature/CustomFixerTest.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * Copyright (c) 2025 Łukasz Zychal
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpstanFixer\Tests\Feature;
+
+use PhpstanFixer\Command\PhpstanAutoFixCommand;
+use PhpstanFixer\FixResult;
+use PhpstanFixer\Issue;
+use PhpstanFixer\Strategy\FixStrategyInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Example custom fixer for testing.
+ */
+final class TestCustomFixer implements FixStrategyInterface
+{
+    public function canFix(Issue $issue): bool
+    {
+        return str_contains($issue->getMessage(), 'Custom error pattern');
+    }
+
+    public function fix(Issue $issue, string $fileContent): FixResult
+    {
+        // Simple fix: add a comment
+        $lines = explode("\n", $fileContent);
+        $lineIndex = $issue->getLine() - 1;
+        
+        if (isset($lines[$lineIndex])) {
+            $lines[$lineIndex] = '// Fixed by CustomFixer' . "\n" . $lines[$lineIndex];
+            $newContent = implode("\n", $lines);
+            return FixResult::success($issue, $newContent, 'Added custom fix comment');
+        }
+        
+        return FixResult::failure($issue, $fileContent, 'Could not apply fix');
+    }
+
+    public function getDescription(): string
+    {
+        return 'Test custom fixer for custom error patterns';
+    }
+
+    public function getName(): string
+    {
+        return 'TestCustomFixer';
+    }
+
+    public function getPriority(): int
+    {
+        return 0;
+    }
+}
+
+/**
+ * @author Łukasz Zychal <lukasz.zychal.dev@gmail.com>
+ */
+final class CustomFixerTest extends TestCase
+{
+    private string $tempDir;
+    private string $tempConfigFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        $this->tempDir = sys_get_temp_dir() . '/phpstan-fixer-test-' . uniqid();
+        mkdir($this->tempDir, 0777, true);
+        $this->tempConfigFile = $this->tempDir . '/phpstan-fixer.json';
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->tempDir)) {
+            $this->removeDirectory($this->tempDir);
+        }
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir . '/' . $file;
+            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    public function testCommandLoadsCustomFixerFromConfig(): void
+    {
+        // Create config with custom fixer
+        $configContent = json_encode([
+            'custom_fixers' => [
+                TestCustomFixer::class,
+            ],
+        ], JSON_PRETTY_PRINT);
+        file_put_contents($this->tempConfigFile, $configContent);
+
+        // Create PHPStan JSON with custom error
+        $phpstanJson = json_encode([
+            'totals' => ['errors' => 1, 'file_errors' => 1],
+            'files' => [
+                'test.php' => [
+                    'errors' => 1,
+                    'messages' => [
+                        [
+                            'message' => 'Custom error pattern detected',
+                            'line' => 5,
+                            'ignorable' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $phpstanFile = $this->tempDir . '/phpstan.json';
+        file_put_contents($phpstanFile, $phpstanJson);
+
+        $application = new Application();
+        $command = new PhpstanAutoFixCommand();
+        $application->add($command);
+        $commandTester = new CommandTester($command);
+
+        // Set config file path via environment or find it automatically
+        $commandTester->execute([
+            '--input' => $phpstanFile,
+            '--mode' => 'suggest',
+        ], [
+            'PHPSTAN_FIXER_CONFIG' => $this->tempConfigFile,
+        ]);
+
+        // Command should execute without errors
+        $this->assertEquals(0, $commandTester->getStatusCode());
+    }
+
+    public function testCommandThrowsWhenCustomFixerClassNotFound(): void
+    {
+        $configContent = json_encode([
+            'custom_fixers' => [
+                'NonExistent\\FixerClass',
+            ],
+        ], JSON_PRETTY_PRINT);
+        file_put_contents($this->tempConfigFile, $configContent);
+
+        $phpstanJson = json_encode([
+            'totals' => ['errors' => 0, 'file_errors' => 0],
+            'files' => [],
+        ]);
+
+        $phpstanFile = $this->tempDir . '/phpstan.json';
+        file_put_contents($phpstanFile, $phpstanJson);
+
+        $application = new Application();
+        $command = new PhpstanAutoFixCommand();
+        $application->add($command);
+        $commandTester = new CommandTester($command);
+
+        $exitCode = $commandTester->execute([
+            '--input' => $phpstanFile,
+            '--mode' => 'suggest',
+            '--config' => $this->tempConfigFile,
+        ]);
+
+        // Should fail with error about missing class
+        $this->assertEquals(1, $exitCode);
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('not found', $output);
+    }
+}
+

--- a/tests/Unit/Configuration/ConfigurationLoaderCustomFixersTest.php
+++ b/tests/Unit/Configuration/ConfigurationLoaderCustomFixersTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Copyright (c) 2025 Łukasz Zychal
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace PhpstanFixer\Tests\Unit\Configuration;
+
+use PhpstanFixer\Configuration\ConfigurationLoader;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Łukasz Zychal <lukasz.zychal.dev@gmail.com>
+ */
+final class ConfigurationLoaderCustomFixersTest extends TestCase
+{
+    private ConfigurationLoader $loader;
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->loader = new ConfigurationLoader();
+        $this->tempDir = sys_get_temp_dir() . '/phpstan-fixer-test-' . uniqid();
+        mkdir($this->tempDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->tempDir)) {
+            $this->removeDirectory($this->tempDir);
+        }
+        parent::tearDown();
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir . '/' . $file;
+            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    public function testLoadFromJsonFileWithCustomFixers(): void
+    {
+        $jsonContent = <<<'JSON'
+{
+  "custom_fixers": [
+    "MyNamespace\\MyCustomFixer",
+    "AnotherNamespace\\AnotherFixer"
+  ]
+}
+JSON;
+
+        $filePath = $this->tempDir . '/phpstan-fixer.json';
+        file_put_contents($filePath, $jsonContent);
+
+        $config = $this->loader->loadFromFile($filePath);
+
+        $this->assertInstanceOf(\PhpstanFixer\Configuration\Configuration::class, $config);
+        $customFixers = $config->getCustomFixers();
+        $this->assertCount(2, $customFixers);
+        $this->assertContains('MyNamespace\\MyCustomFixer', $customFixers);
+        $this->assertContains('AnotherNamespace\\AnotherFixer', $customFixers);
+    }
+
+    public function testLoadFromYamlFileWithCustomFixers(): void
+    {
+        if (!function_exists('yaml_parse') && !class_exists(\Symfony\Component\Yaml\Yaml::class)) {
+            $this->markTestSkipped('YAML extension or Symfony YAML is not available');
+            /** @phpstan-ignore-next-line - PHPStan doesn't understand that markTestSkipped() may not always throw */
+            return;
+        }
+
+        $yamlContent = <<<'YAML'
+custom_fixers:
+  - MyNamespace\MyCustomFixer
+  - AnotherNamespace\AnotherFixer
+YAML;
+
+        $filePath = $this->tempDir . '/phpstan-fixer.yaml';
+        file_put_contents($filePath, $yamlContent);
+
+        $config = $this->loader->loadFromFile($filePath);
+
+        $this->assertInstanceOf(\PhpstanFixer\Configuration\Configuration::class, $config);
+        $this->assertCount(2, $config->getCustomFixers());
+    }
+
+    public function testThrowsWhenCustomFixersIsNotArray(): void
+    {
+        $jsonContent = <<<'JSON'
+{
+  "custom_fixers": "not-an-array"
+}
+JSON;
+
+        $filePath = $this->tempDir . '/phpstan-fixer.json';
+        file_put_contents($filePath, $jsonContent);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Configuration "custom_fixers" must be an array');
+
+        $this->loader->loadFromFile($filePath);
+    }
+
+    public function testThrowsWhenCustomFixerIsNotString(): void
+    {
+        $jsonContent = <<<'JSON'
+{
+  "custom_fixers": [
+    "ValidFixer",
+    123
+  ]
+}
+JSON;
+
+        $filePath = $this->tempDir . '/phpstan-fixer.json';
+        file_put_contents($filePath, $jsonContent);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Configuration "custom_fixers[1]" must be a string');
+
+        $this->loader->loadFromFile($filePath);
+    }
+}
+

--- a/tests/Unit/Configuration/ConfigurationLoaderTest.php
+++ b/tests/Unit/Configuration/ConfigurationLoaderTest.php
@@ -114,6 +114,7 @@ JSON;
         // Skip test if yaml extension is available
         if (function_exists('yaml_parse') || class_exists(\Symfony\Component\Yaml\Yaml::class)) {
             $this->markTestSkipped('YAML extension or Symfony YAML is available');
+            /** @phpstan-ignore-next-line - PHPStan doesn't understand that markTestSkipped() may not always throw */
             return;
         }
 
@@ -138,6 +139,7 @@ YAML;
     {
         if (!function_exists('yaml_parse') && !class_exists(\Symfony\Component\Yaml\Yaml::class)) {
             $this->markTestSkipped('YAML extension or Symfony YAML is not available');
+            /** @phpstan-ignore-next-line - PHPStan doesn't understand that markTestSkipped() may not always throw */
             return;
         }
 


### PR DESCRIPTION
## Summary

This PR adds support for custom fixer strategies that users can register via configuration file.

## Changes

### Configuration
- Added `custom_fixers` section to configuration (JSON/YAML)
- Support for registering custom fixer classes by FQN
- Validation of custom fixer classes (must exist and implement `FixStrategyInterface`)

### Implementation
- Extended `Configuration` class with `getCustomFixers()` method
- Added parsing of `custom_fixers` in `ConfigurationLoader`
- Implemented `loadCustomFixers()` method in `PhpstanAutoFixCommand`
- Automatic dependency injection for `PhpFileAnalyzer` and `DocblockManipulator`
- Error handling for missing classes and invalid interfaces

### Testing
- Added unit tests for `ConfigurationLoader` custom fixers parsing (4 tests)
- Added integration tests for custom fixer loading (2 tests)
- Fixed PHPStan false positives in `ConfigurationLoaderTest`

## Usage

Users can now register custom fixers in their `phpstan-fixer.json` or `phpstan-fixer.yaml`:

```json
{
  "custom_fixers": [
    "MyNamespace\MyCustomFixer",
    "AnotherNamespace\AnotherFixer"
  ]
}
```

Custom fixers must:
- Implement `FixStrategyInterface`
- Be autoloadable (via Composer or custom autoloader)
- Accept optional dependencies (`PhpFileAnalyzer`, `DocblockManipulator`) in constructor

## Testing

- ✅ All PHPUnit tests pass (195 tests, 386 assertions)
- ✅ PHPStan level 5: No errors
- ✅ Pre-commit checks: All passed

## Related

Part of v1.2.0 implementation plan - Sprint 3

Closes: Custom fixers feature from roadmap