### PR TITLE
fix: update compatibility-tests workflow to run on PR/push

### DIFF
--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -1,15 +1,19 @@
 name: Compatibility Tests
 
 on:
+  # Run on push to main/develop branches
+  push:
+    branches: [ main, develop ]
+    tags:
+      - 'v*'
+  # Run on pull requests to main/develop
+  pull_request:
+    branches: [ main, develop ]
   # Run monthly on the 1st day at 2 AM UTC
   schedule:
     - cron: '0 2 1 * *'  # Monthly on 1st day at 2 AM UTC
   # Manual trigger (workflow_dispatch)
   workflow_dispatch:
-  # Optional: Run on release tags (uncomment if needed)
-  # push:
-  #   tags:
-  #     - 'v*'
 
 jobs:
   compatibility-tests:


### PR DESCRIPTION
## Summary

This PR updates the compatibility-tests workflow to run automatically on pull requests and pushes, not just on schedule.

## Changes

- Added `push` trigger for `main`/`develop` branches and `v*` tags
- Added `pull_request` trigger for PRs targeting `main`/`develop`
- Kept existing `schedule` (monthly) and `workflow_dispatch` (manual) triggers

## Benefits

- Compatibility tests run before PR merge (catches issues early)
- Compatibility verified on every push to main branches
- Automatic tests on release tags
- Monthly reports still generated via schedule

## Testing

The workflow will run automatically when this PR is created, verifying the changes work correctly.